### PR TITLE
Add generic reduction observer for usage in GH evolution

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -38,8 +38,7 @@ Scalar<DataType> magnitude(
     const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector,
     const Tensor<DataType, Symmetry<1, 1>,
                  index_list<change_index_up_lo<Index>,
-                            change_index_up_lo<Index>>>&
-        metric) noexcept {
+                            change_index_up_lo<Index>>>& metric) noexcept {
   return Scalar<DataType>{sqrt(get(dot_product(vector, vector, metric)))};
 }
 
@@ -104,6 +103,7 @@ struct Normalized : db::ComputeTag {
     }
     return vector;
   }
+  using type = typename Tag::type;
   using argument_tags = tmpl::list<Tag, Magnitude<Tag>>;
 };
 }  // namespace Tags

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -13,8 +13,12 @@
 #include <unordered_map>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -74,6 +78,53 @@ struct UnnormalizedFaceNormal : db::ComputeTag {
       tmpl::list<Mesh<VolumeDim - 1>, ElementMap<VolumeDim, Frame>,
                  Direction<VolumeDim>>;
   using volume_tags = tmpl::list<ElementMap<VolumeDim, Frame>>;
+};
+
+template <size_t Dim, typename Frame>
+struct UnitFaceNormal : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UnitFaceNormal"; }
+};
+
+template <size_t Dim, typename Frame>
+struct UnitFaceNormalCompute : UnitFaceNormal<Dim, Frame>, db::ComputeTag {
+  static constexpr auto function(
+      const db::item_type<UnnormalizedFaceNormal<Dim, Frame>>&
+          vector_in,  // Compute items need to take const references
+      const db::item_type<Magnitude<UnnormalizedFaceNormal<Dim, Frame>>>&
+          magnitude) noexcept {
+    auto vector = vector_in;
+    for (size_t d = 0; d < vector.index_dim(0); ++d) {
+      vector.get(d) /= get(magnitude);
+    }
+    return vector;
+  }
+  using argument_tags =
+      tmpl::list<UnnormalizedFaceNormal<Dim, Frame>,
+                 Magnitude<UnnormalizedFaceNormal<Dim, Frame>>>;
+  using base = UnitFaceNormal<Dim, Frame>;
+  using type = typename base::type;
+};
+
+template <size_t Dim, typename Frame>
+struct UnitFaceNormalVector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UnitFaceNormalVector"; }
+};
+
+template <size_t SpatialDim, typename Frame>
+struct UnitFaceNormalVectorCompute : UnitFaceNormalVector<SpatialDim, Frame>,
+                                     db::ComputeTag {
+  static constexpr tnsr::I<DataVector, SpatialDim, Frame> (*function)(
+      const tnsr::i<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&) =
+      &raise_or_lower_index<DataVector,
+                            SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+  using argument_tags =
+      tmpl::list<UnitFaceNormal<SpatialDim, Frame>,
+                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>>;
+  using base = UnitFaceNormalVector<SpatialDim, Frame>;
+  using type = typename base::type;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -71,60 +71,14 @@ namespace Tags {
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct UnnormalizedFaceNormal : db::ComputeTag {
   static std::string name() noexcept { return "UnnormalizedFaceNormal"; }
-  static constexpr tnsr::i<DataVector, VolumeDim, Frame> (*function)(
+  using type = tnsr::i<DataVector, VolumeDim, Frame>;
+  static constexpr type (*function)(
       const ::Mesh<VolumeDim - 1>&, const ::ElementMap<VolumeDim, Frame>&,
       const ::Direction<VolumeDim>&) = unnormalized_face_normal;
   using argument_tags =
       tmpl::list<Mesh<VolumeDim - 1>, ElementMap<VolumeDim, Frame>,
                  Direction<VolumeDim>>;
   using volume_tags = tmpl::list<ElementMap<VolumeDim, Frame>>;
-};
-
-template <size_t Dim, typename Frame>
-struct UnitFaceNormal : db::SimpleTag {
-  using type = tnsr::i<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "UnitFaceNormal"; }
-};
-
-template <size_t Dim, typename Frame>
-struct UnitFaceNormalCompute : UnitFaceNormal<Dim, Frame>, db::ComputeTag {
-  static constexpr auto function(
-      const db::item_type<UnnormalizedFaceNormal<Dim, Frame>>&
-          vector_in,  // Compute items need to take const references
-      const db::item_type<Magnitude<UnnormalizedFaceNormal<Dim, Frame>>>&
-          magnitude) noexcept {
-    auto vector = vector_in;
-    for (size_t d = 0; d < vector.index_dim(0); ++d) {
-      vector.get(d) /= get(magnitude);
-    }
-    return vector;
-  }
-  using argument_tags =
-      tmpl::list<UnnormalizedFaceNormal<Dim, Frame>,
-                 Magnitude<UnnormalizedFaceNormal<Dim, Frame>>>;
-  using base = UnitFaceNormal<Dim, Frame>;
-  using type = typename base::type;
-};
-
-template <size_t Dim, typename Frame>
-struct UnitFaceNormalVector : db::SimpleTag {
-  using type = tnsr::I<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "UnitFaceNormalVector"; }
-};
-
-template <size_t SpatialDim, typename Frame>
-struct UnitFaceNormalVectorCompute : UnitFaceNormalVector<SpatialDim, Frame>,
-                                     db::ComputeTag {
-  static constexpr tnsr::I<DataVector, SpatialDim, Frame> (*function)(
-      const tnsr::i<DataVector, SpatialDim, Frame>&,
-      const tnsr::II<DataVector, SpatialDim, Frame>&) =
-      &raise_or_lower_index<DataVector,
-                            SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
-  using argument_tags =
-      tmpl::list<UnitFaceNormal<SpatialDim, Frame>,
-                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>>;
-  using base = UnitFaceNormalVector<SpatialDim, Frame>;
-  using type = typename base::type;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Evolution/DiscontinuousGalerkin/ObserveNorms.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/ObserveNorms.hpp
@@ -1,0 +1,172 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ReductionActions.hpp"   // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Tags {
+struct Time;
+}  // namespace Tags
+/// \endcond
+
+namespace dg {
+namespace Events {
+template <size_t VolumeDim, typename Tensors, typename EventRegistrars>
+class ObserveNorms;
+
+namespace Registrars {
+template <size_t VolumeDim, typename Tensors>
+struct ObserveNorms {
+  template <typename RegistrarList>
+  using f = Events::ObserveNorms<VolumeDim, Tensors, RegistrarList>;
+};
+}  // namespace Registrars
+
+template <size_t VolumeDim, typename Tensors,
+          typename EventRegistrars =
+              tmpl::list<Registrars::ObserveNorms<VolumeDim, Tensors>>>
+class ObserveNorms;  // IWYU pragma: keep
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief %Observe the RMS values of tensors (averaged over all grid points
+ * and all indices).
+ *
+ * Writes reduction quantities:
+ * - `Time`
+ * - `NumberOfPoints` = total number of points in the domain
+ * - `Norm(*)` = RMS values in `Tensors` =
+ *   \f$\operatorname{RMS}\left(\sqrt{\sum_{\text{independent components}}\left[
+ *   \text{value} \right]^2}\right)\f$
+ *   over all points
+ *
+ * \warning Currently, only one reduction observation event can be
+ * triggered at a given time.  Causing multiple events to run at once
+ * will produce unpredictable results.
+ */
+template <size_t VolumeDim, typename... Tensors, typename EventRegistrars>
+class ObserveNorms<VolumeDim, tmpl::list<Tensors...>, EventRegistrars>
+    : public Event<EventRegistrars> {
+ private:
+  using coordinates_tag = ::Tags::Coordinates<VolumeDim, Frame::Inertial>;
+
+  template <typename Tag>
+  struct LocalSquareNorm {
+    using type = double;
+  };
+
+  using L2NormDatum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                               funcl::Sqrt<funcl::Divides<>>,
+                                               std::index_sequence<1>>;
+  using ReductionData = tmpl::wrap<
+      tmpl::append<
+          tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+                     Parallel::ReductionDatum<size_t, funcl::Plus<>>>,
+          tmpl::filled_list<L2NormDatum, sizeof...(Tensors)>>,
+      Parallel::ReductionData>;
+
+ public:
+  /// \cond
+  explicit ObserveNorms(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveNorms);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr OptionString help =
+      "Observe the RMS values of tensors (averaged over all grid points\n"
+      "and all indices).\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      " * Time\n"
+      " * NumberOfPoints = total number of points in the domain\n"
+      " * Norm(*) = RMS values in Tensors (see online help details)\n"
+      "\n"
+      "Warning: Currently, only one reduction observation event can be\n"
+      "triggered at a given time.  Causing multiple events to run at once\n"
+      "will produce unpredictable results.";
+
+  ObserveNorms() = default;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using argument_tags = tmpl::list<::Tags::Time, coordinates_tag, Tensors...>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(
+      const Time& time,
+      const db::item_type<coordinates_tag>& /*inertial_coordinates*/,
+      const db::item_type<Tensors>&... tensors,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const noexcept {
+    tuples::TaggedTuple<LocalSquareNorm<Tensors>...> local_square_norms;
+    const auto record_norms = [&local_square_norms](
+        const auto tensor_tag_v, const auto& tensor) noexcept {
+      using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
+      double local_square_norm = 0.0;
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        local_square_norm += alg::accumulate(square(tensor[i]), 0.0);
+      }
+      get<LocalSquareNorm<tensor_tag>>(local_square_norms) = local_square_norm;
+      return 0;
+    };
+    expand_pack(record_norms(tmpl::type_<Tensors>{}, tensors)...);
+    const size_t num_points = get_first_argument(tensors...).begin()->size();
+
+    // Send data to reduction observer
+    auto& local_observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+        local_observer,
+        observers::ObservationId(
+            time.value(), typename Metavariables::element_observation_type{}),
+        std::string{"/element_data"},
+        std::vector<std::string>{"Time", "NumberOfPoints",
+                                 ("L2Norm(" + Tensors::name() + ")")...},
+        ReductionData{
+            time.value(), num_points,
+            std::move(get<LocalSquareNorm<Tensors>>(local_square_norms))...});
+  }
+};
+
+/// \cond
+template <size_t VolumeDim, typename... Tensors, typename EventRegistrars>
+PUP::able::PUP_ID ObserveNorms<VolumeDim, tmpl::list<Tensors...>,
+                               EventRegistrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Events
+}  // namespace dg

--- a/src/Evolution/Executables/CMakeLists.txt
+++ b/src/Evolution/Executables/CMakeLists.txt
@@ -2,5 +2,6 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Burgers)
+add_subdirectory(GeneralizedHarmonic)
 add_subdirectory(GrMhd)
 add_subdirectory(ScalarWave)

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBS_TO_LINK
+    CoordinateMaps
+    DiscontinuousGalerkin
+    Domain
+    DomainCreators
+    GeneralRelativity
+    GeneralRelativitySolutions
+    GeneralizedHarmonic
+    IO
+    Informer
+    LinearOperators
+    MathFunctions
+    Time
+    Utilities
+    ${SPECTRE_LIBRARIES}
+  )
+
+add_spectre_parallel_executable(
+  EvolveGeneralizedHarmonic
+  EvolveGeneralizedHarmonic
+  Evolution/Executables/GeneralizedHarmonic
+  EvolutionMetavars
+  "${LIBS_TO_LINK}"
+)

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -34,7 +34,6 @@
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrapGh.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"  // IWYU pragma: keep
@@ -139,7 +138,7 @@ struct EvolutionMetavars {
 
   static constexpr OptionString help{
       "Evolve a generalized harmonic analytic solution.\n\n"
-      "The analytic solution is: Minkowski\n"
+      "The analytic solution is: KerrSchild\n"
       "The numerical flux is:    UpwindFlux\n"};
 
   enum class Phase { Initialization, RegisterWithObserver, Evolve, Exit };

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -1,0 +1,180 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"  // IWYU pragma: keep // for UpwindFlux
+#include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Observe.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/GotoAction.hpp"  // IWYU pragma: keep
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrapGh.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Time/Actions/AdvanceTime.hpp"            // IWYU pragma: keep
+#include "Time/Actions/ChangeStepSize.hpp"         // IWYU pragma: keep
+#include "Time/Actions/FinalTime.hpp"              // IWYU pragma: keep
+#include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
+#include "Time/Actions/SelfStartActions.hpp"       // IWYU pragma: keep
+#include "Time/Actions/UpdateU.hpp"                // IWYU pragma: keep
+#include "Time/StepChoosers/Cfl.hpp"               // IWYU pragma: keep
+#include "Time/StepChoosers/Constant.hpp"          // IWYU pragma: keep
+#include "Time/StepChoosers/Increase.hpp"          // IWYU pragma: keep
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepControllers/StepController.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+// IWYU pragma: no_forward_declare MathFunction
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class CProxy_ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+struct EvolutionMetavars {
+  // Customization/"input options" to simulation
+  static constexpr int dim = 3;
+  using Inertial = Frame::Inertial;
+  using system = GeneralizedHarmonic::System<dim>;
+  using temporal_id = Tags::TimeId;
+  static constexpr bool local_time_stepping = false;
+  using analytic_solution_tag = OptionTags::AnalyticSolution<
+      GeneralizedHarmonic::Solutions::WrapGh<gr::Solutions::KerrSchild>>;
+  using boundary_condition_tag = analytic_solution_tag;
+  using normal_dot_numerical_flux = OptionTags::NumericalFluxParams<
+      // dg::NumericalFluxes::LocalLaxFriedrichs<system>>;
+      GeneralizedHarmonic::UpwindFlux<dim>>;
+  // A tmpl::list of tags to be added to the ConstGlobalCache by the
+  // metavariables
+  using const_global_cache_tag_list =
+      tmpl::list<analytic_solution_tag,
+                 OptionTags::TypedTimeStepper<tmpl::conditional_t<
+                     local_time_stepping, LtsTimeStepper, TimeStepper>>>;
+  using domain_creator_tag = OptionTags::DomainCreator<dim, Inertial>;
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::list<GeneralizedHarmonic::Actions::Observe>>;
+
+  using step_choosers = tmpl::list<StepChoosers::Registrars::Cfl<dim, Inertial>,
+                                   StepChoosers::Registrars::Constant,
+                                   StepChoosers::Registrars::Increase>;
+
+  using compute_rhs = tmpl::flatten<tmpl::list<
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          Tags::InternalDirections<dim>>,
+      dg::Actions::SendDataForFluxes<EvolutionMetavars>,
+      Actions::ComputeTimeDerivative,
+      dg::Actions::ComputeNonconservativeBoundaryFluxes<
+          Tags::BoundaryDirectionsInterior<dim>>,
+      dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
+      dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
+      tmpl::conditional_t<local_time_stepping, tmpl::list<>,
+                          dg::Actions::ApplyFluxes>,
+      Actions::RecordTimeStepperData>>;
+  using update_variables = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<local_time_stepping,
+                          dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
+                          tmpl::list<>>,
+      Actions::UpdateU>>;
+
+  struct EvolvePhaseStart;
+  using component_list = tmpl::list<
+      observers::Observer<EvolutionMetavars>,
+      observers::ObserverWriter<EvolutionMetavars>,
+      DgElementArray<
+          EvolutionMetavars, GeneralizedHarmonic::Actions::Initialize<dim>,
+          tmpl::flatten<tmpl::list<
+              SelfStart::self_start_procedure<compute_rhs, update_variables>,
+              Actions::Label<EvolvePhaseStart>, Actions::AdvanceTime,
+              GeneralizedHarmonic::Actions::Observe, Actions::FinalTime,
+              tmpl::conditional_t<local_time_stepping,
+                                  Actions::ChangeStepSize<step_choosers>,
+                                  tmpl::list<>>,
+              compute_rhs, update_variables,
+              Actions::Goto<EvolvePhaseStart>>>>>;
+
+  static constexpr OptionString help{
+      "Evolve a generalized harmonic analytic solution.\n\n"
+      "The analytic solution is: Minkowski\n"
+      "The numerical flux is:    UpwindFlux\n"};
+
+  enum class Phase { Initialization, RegisterWithObserver, Evolve, Exit };
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> an integral "
+            "value?");
+    }
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling,
+    &domain::creators::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<MathFunction<1>>,
+    &Parallel::register_derived_classes_with_charm<
+        StepChooser<metavariables::step_choosers>>,
+    &Parallel::register_derived_classes_with_charm<StepController>,
+    &Parallel::register_derived_classes_with_charm<TimeStepper>};
+
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicFwd.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+struct EvolutionMetavars;

--- a/src/Evolution/Initialization/GeneralizedHarmonicInterface.hpp
+++ b/src/Evolution/Initialization/GeneralizedHarmonicInterface.hpp
@@ -1,0 +1,165 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Initialization {
+
+/// \brief Initialize items related to the interfaces between Elements and on
+/// external boundaries, for non-conservative systems
+///
+/// DataBox changes:
+/// - Adds:
+///   * `face_tags<Tags::InternalDirections<Dim>>`
+///   * `face_tags<Tags::BoundaryDirectionsInterior<Dim>>`
+///   * `face_tags<Tags::BoundaryDirectionsExterior<Dim>>`
+///
+/// - For face_tags:
+///   * `Tags::InterfaceComputeItem<Directions, Tags::Direction<Dim>>`
+///   * `Tags::InterfaceComputeItem<Directions, Tags::InterfaceMesh<Dim>>`
+///   * `Tags::Slice<Directions, typename System::variables_tag>`
+///   * `Tags::InterfaceComputeItem<Directions,
+///                                Tags::UnnormalizedFaceNormal<Dim>>`
+///   * Tags::InterfaceComputeItem<Directions,
+///                                typename System::template magnitude_tag<
+///                                    Tags::UnnormalizedFaceNormal<Dim>>>
+///   * `Tags::InterfaceComputeItem<
+///         Directions, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>`
+/// - Removes: nothing
+/// - Modifies: nothing
+template <typename System>
+struct GeneralizedHarmonicInterface {
+  static constexpr size_t dim = System::volume_dim;
+  using Inertial = Frame::Inertial;
+  using simple_tags =
+      db::AddSimpleTags<Tags::Interface<Tags::BoundaryDirectionsExterior<dim>,
+                                        typename System::variables_tag>>;
+
+  template <typename Directions>
+  using face_tags = tmpl::list<
+      Directions, Tags::InterfaceComputeItem<Directions, Tags::Direction<dim>>,
+      Tags::InterfaceComputeItem<Directions, Tags::InterfaceMesh<dim>>,
+      Tags::InterfaceComputeItem<Directions,
+                                 Tags::BoundaryCoordinates<dim, Inertial>>,
+      Tags::Slice<Directions, typename System::variables_tag>,
+      Tags::InterfaceComputeItem<
+          Directions,
+          GeneralizedHarmonic::Tags::ConstraintGamma0Compute<dim, Inertial>>,
+      Tags::InterfaceComputeItem<
+          Directions,
+          GeneralizedHarmonic::Tags::ConstraintGamma1Compute<dim, Inertial>>,
+      Tags::InterfaceComputeItem<
+          Directions,
+          GeneralizedHarmonic::Tags::ConstraintGamma2Compute<dim, Inertial>>,
+      Tags::InterfaceComputeItem<Directions, gr::Tags::SpatialMetricCompute<
+                                                 dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<
+          Directions, gr::Tags::DetAndInverseSpatialMetricCompute<dim, Inertial,
+                                                                  DataVector>>,
+      Tags::InterfaceComputeItem<
+          Directions,
+          gr::Tags::InverseSpatialMetricCompute<dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<
+          Directions, gr::Tags::ShiftCompute<dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<
+          Directions, gr::Tags::LapseCompute<dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<Directions, Tags::UnnormalizedFaceNormal<dim>>,
+      Tags::InterfaceComputeItem<Directions,
+                                 typename System::template magnitude_tag<
+                                     Tags::UnnormalizedFaceNormal<dim>>>,
+      Tags::InterfaceComputeItem<
+          Directions,
+          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<dim, Inertial>>>,
+      Tags::InterfaceComputeItem<
+          Directions,
+          GeneralizedHarmonic::CharacteristicFieldsCompute<dim, Inertial>>,
+      Tags::InterfaceComputeItem<
+          Directions,
+          GeneralizedHarmonic::CharacteristicSpeedsCompute<dim, Inertial>>>;
+
+  using ext_tags = tmpl::list<
+      Tags::BoundaryDirectionsExterior<dim>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          gr::Tags::SpatialMetricCompute<dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 gr::Tags::DetAndInverseSpatialMetricCompute<
+                                     dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          gr::Tags::InverseSpatialMetricCompute<dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          gr::Tags::ShiftCompute<dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          gr::Tags::LapseCompute<dim, Inertial, DataVector>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::Direction<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::InterfaceMesh<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::BoundaryCoordinates<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::UnnormalizedFaceNormal<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 typename System::template magnitude_tag<
+                                     Tags::UnnormalizedFaceNormal<dim>>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          GeneralizedHarmonic::Tags::ConstraintGamma0Compute<dim, Inertial>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          GeneralizedHarmonic::Tags::ConstraintGamma1Compute<dim, Inertial>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          GeneralizedHarmonic::Tags::ConstraintGamma2Compute<dim, Inertial>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          ::Tags::Normalized<
+              ::Tags::UnnormalizedFaceNormal<dim, Frame::Inertial>>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          GeneralizedHarmonic::CharacteristicFieldsCompute<dim, Inertial>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          GeneralizedHarmonic::CharacteristicSpeedsCompute<dim, Inertial>>>;
+
+  using compute_tags =
+      tmpl::append<face_tags<Tags::InternalDirections<dim>>,
+                   face_tags<Tags::BoundaryDirectionsInterior<dim>>, ext_tags>;
+
+  template <typename TagsList>
+  static auto initialize(db::DataBox<TagsList>&& box) noexcept {
+    const auto& mesh = db::get<Tags::Mesh<dim>>(box);
+    std::unordered_map<Direction<dim>,
+                       db::item_type<typename System::variables_tag>>
+        external_boundary_vars{};
+
+    for (const auto& direction :
+         db::get<Tags::Element<dim>>(box).external_boundaries()) {
+      external_boundary_vars[direction] =
+          db::item_type<typename System::variables_tag>{
+              mesh.slice_away(direction.dimension()).number_of_grid_points()};
+    }
+
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box), std::move(external_boundary_vars));
+  }
+};
+
+}  // namespace Initialization

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -20,7 +20,7 @@
 namespace GeneralizedHarmonic {
 
 template <size_t Dim, typename Frame>
-void compute_characteristic_speeds(
+void characteristic_speeds(
     const gsl::not_null<typename Tags::CharacteristicSpeeds<Dim, Frame>::type*>
         char_speeds,
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
@@ -34,21 +34,20 @@ void compute_characteristic_speeds(
 }
 
 template <size_t Dim, typename Frame>
-typename Tags::CharacteristicSpeeds<Dim, Frame>::type
-CharacteristicSpeedsCompute<Dim, Frame>::function(
+typename Tags::CharacteristicSpeeds<Dim, Frame>::type characteristic_speeds(
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
   auto char_speeds =
       make_with_value<typename Tags::CharacteristicSpeeds<Dim, Frame>::type>(
           get(lapse), 0.);
-  compute_characteristic_speeds(make_not_null(&char_speeds), gamma_1, lapse,
-                                shift, unit_normal_one_form);
+  characteristic_speeds(make_not_null(&char_speeds), gamma_1, lapse, shift,
+                        unit_normal_one_form);
   return char_speeds;
 }
 
 template <size_t Dim, typename Frame>
-void compute_characteristic_fields(
+void characteristic_fields(
     const gsl::not_null<typename Tags::CharacteristicFields<Dim, Frame>::type*>
         char_fields,
     const Scalar<DataVector>& gamma_2,
@@ -100,8 +99,7 @@ void compute_characteristic_fields(
 }
 
 template <size_t Dim, typename Frame>
-typename Tags::CharacteristicFields<Dim, Frame>::type
-CharacteristicFieldsCompute<Dim, Frame>::function(
+typename Tags::CharacteristicFields<Dim, Frame>::type characteristic_fields(
     const Scalar<DataVector>& gamma_2,
     const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
     const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
@@ -111,14 +109,14 @@ CharacteristicFieldsCompute<Dim, Frame>::function(
   auto char_fields =
       make_with_value<typename Tags::CharacteristicFields<Dim, Frame>::type>(
           get(gamma_2), 0.);
-  compute_characteristic_fields(make_not_null(&char_fields), gamma_2,
-                                inverse_spatial_metric, spacetime_metric, pi,
-                                phi, unit_normal_one_form);
+  characteristic_fields(make_not_null(&char_fields), gamma_2,
+                        inverse_spatial_metric, spacetime_metric, pi, phi,
+                        unit_normal_one_form);
   return char_fields;
 }
 
 template <size_t Dim, typename Frame>
-void compute_evolved_fields_from_characteristic_fields(
+void evolved_fields_from_characteristic_fields(
     const gsl::not_null<
         typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type*>
         evolved_fields,
@@ -150,7 +148,7 @@ void compute_evolved_fields_from_characteristic_fields(
 
 template <size_t Dim, typename Frame>
 typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type
-EvolvedFieldsFromCharacteristicFieldsCompute<Dim, Frame>::function(
+evolved_fields_from_characteristic_fields(
     const Scalar<DataVector>& gamma_2,
     const tnsr::aa<DataVector, Dim, Frame>& u_psi,
     const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
@@ -160,9 +158,9 @@ EvolvedFieldsFromCharacteristicFieldsCompute<Dim, Frame>::function(
   auto evolved_fields = make_with_value<
       typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type>(
       get(gamma_2), 0.);
-  compute_evolved_fields_from_characteristic_fields(
-      make_not_null(&evolved_fields), gamma_2, u_psi, u_zero, u_plus, u_minus,
-      unit_normal_one_form);
+  evolved_fields_from_characteristic_fields(make_not_null(&evolved_fields),
+                                            gamma_2, u_psi, u_zero, u_plus,
+                                            u_minus, unit_normal_one_form);
   return evolved_fields;
 }
 
@@ -179,49 +177,77 @@ double ComputeLargestCharacteristicSpeed<Dim, Frame>::apply(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(_, data)                                              \
-  template void GeneralizedHarmonic::compute_characteristic_speeds(         \
-      const gsl::not_null<                                                  \
-          typename GeneralizedHarmonic::Tags::CharacteristicSpeeds<         \
-              DIM(data), FRAME(data)>::type*>                               \
-          char_speeds,                                                      \
-      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,   \
-      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,             \
-      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                    \
-          unit_normal_one_form) noexcept;                                   \
-  template struct GeneralizedHarmonic::CharacteristicSpeedsCompute<         \
-      DIM(data), FRAME(data)>;                                              \
-  template void GeneralizedHarmonic::compute_characteristic_fields(         \
-      const gsl::not_null<                                                  \
-          typename GeneralizedHarmonic::Tags::CharacteristicFields<         \
-              DIM(data), FRAME(data)>::type*>                               \
-          char_fields,                                                      \
-      const Scalar<DataVector>& gamma_2,                                    \
-      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                   \
-          inverse_spatial_metric,                                           \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric, \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,               \
-      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,             \
-      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                    \
-          unit_normal_one_form) noexcept;                                   \
-  template struct GeneralizedHarmonic::CharacteristicFieldsCompute<         \
-      DIM(data), FRAME(data)>;                                              \
-  template void                                                             \
-  GeneralizedHarmonic::compute_evolved_fields_from_characteristic_fields(   \
-      const gsl::not_null<typename GeneralizedHarmonic::Tags::              \
-                              EvolvedFieldsFromCharacteristicFields<        \
-                                  DIM(data), FRAME(data)>::type*>           \
-          evolved_fields,                                                   \
-      const Scalar<DataVector>& gamma_2,                                    \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_psi,            \
-      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& u_zero,          \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_plus,           \
-      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_minus,          \
-      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                    \
-          unit_normal_one_form) noexcept;                                   \
-  template struct GeneralizedHarmonic::                                     \
-      EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data), FRAME(data)>; \
-  template struct GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<   \
+#define INSTANTIATION(_, data)                                                \
+  template void GeneralizedHarmonic::characteristic_speeds(                   \
+      const gsl::not_null<                                                    \
+          typename GeneralizedHarmonic::Tags::CharacteristicSpeeds<           \
+              DIM(data), FRAME(data)>::type*>                                 \
+          char_speeds,                                                        \
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,     \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,               \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
+          unit_normal_one_form) noexcept;                                     \
+  template GeneralizedHarmonic::Tags::CharacteristicSpeeds<DIM(data),         \
+                                                           FRAME(data)>::type \
+  GeneralizedHarmonic::characteristic_speeds(                                 \
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,     \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,               \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
+          unit_normal_one_form) noexcept;                                     \
+  template struct GeneralizedHarmonic::CharacteristicSpeedsCompute<           \
+      DIM(data), FRAME(data)>;                                                \
+  template void GeneralizedHarmonic::characteristic_fields(                   \
+      const gsl::not_null<                                                    \
+          typename GeneralizedHarmonic::Tags::CharacteristicFields<           \
+              DIM(data), FRAME(data)>::type*>                                 \
+          char_fields,                                                        \
+      const Scalar<DataVector>& gamma_2,                                      \
+      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                     \
+          inverse_spatial_metric,                                             \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,   \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,                 \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,               \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
+          unit_normal_one_form) noexcept;                                     \
+  template typename GeneralizedHarmonic::Tags::CharacteristicFields<          \
+      DIM(data), FRAME(data)>::type                                           \
+  GeneralizedHarmonic::characteristic_fields(                                 \
+      const Scalar<DataVector>& gamma_2,                                      \
+      const tnsr::II<DataVector, DIM(data), FRAME(data)>&                     \
+          inverse_spatial_metric,                                             \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,   \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,                 \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,               \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
+          unit_normal_one_form) noexcept;                                     \
+  template struct GeneralizedHarmonic::CharacteristicFieldsCompute<           \
+      DIM(data), FRAME(data)>;                                                \
+  template void                                                               \
+  GeneralizedHarmonic::evolved_fields_from_characteristic_fields(             \
+      const gsl::not_null<typename GeneralizedHarmonic::Tags::                \
+                              EvolvedFieldsFromCharacteristicFields<          \
+                                  DIM(data), FRAME(data)>::type*>             \
+          evolved_fields,                                                     \
+      const Scalar<DataVector>& gamma_2,                                      \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_psi,              \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& u_zero,            \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_plus,             \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_minus,            \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                      \
+          unit_normal_one_form) noexcept;                                     \
+  template typename GeneralizedHarmonic::Tags::                               \
+      EvolvedFieldsFromCharacteristicFields<DIM(data), FRAME(data)>::type     \
+      GeneralizedHarmonic::evolved_fields_from_characteristic_fields(         \
+          const Scalar<DataVector>& gamma_2,                                  \
+          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_psi,          \
+          const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& u_zero,        \
+          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_plus,         \
+          const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_minus,        \
+          const tnsr::i<DataVector, DIM(data), FRAME(data)>&                  \
+              unit_normal_one_form) noexcept;                                 \
+  template struct GeneralizedHarmonic::                                       \
+      EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data), FRAME(data)>;   \
+  template struct GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<     \
       DIM(data), FRAME(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -59,6 +59,20 @@ namespace GeneralizedHarmonic {
  * surface.
  */
 template <size_t Dim, typename Frame>
+typename Tags::CharacteristicSpeeds<Dim, Frame>::type characteristic_speeds(
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+
+template <size_t Dim, typename Frame>
+void characteristic_speeds(
+    gsl::not_null<typename Tags::CharacteristicSpeeds<Dim, Frame>::type*>
+        char_speeds,
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+
+template <size_t Dim, typename Frame>
 struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim, Frame>,
                                      db::ComputeTag {
   using base = Tags::CharacteristicSpeeds<Dim, Frame>;
@@ -71,16 +85,10 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim, Frame>,
   static typename Tags::CharacteristicSpeeds<Dim, Frame>::type function(
       const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim, Frame>& shift,
-      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
+    return characteristic_speeds(gamma_1, lapse, shift, unit_normal_one_form);
+  };
 };
-
-template <size_t Dim, typename Frame>
-void compute_characteristic_speeds(
-    gsl::not_null<typename Tags::CharacteristicSpeeds<Dim, Frame>::type*>
-        char_speeds,
-    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, Dim, Frame>& shift,
-    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
 // @}
 
 // @{
@@ -131,6 +139,26 @@ void compute_characteristic_speeds(
  * \ref CharacteristicSpeedsCompute .
  */
 template <size_t Dim, typename Frame>
+typename Tags::CharacteristicFields<Dim, Frame>::type characteristic_fields(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame>& phi,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+
+template <size_t Dim, typename Frame>
+void characteristic_fields(
+    gsl::not_null<typename Tags::CharacteristicFields<Dim, Frame>::type*>
+        char_fields,
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame>& phi,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+
+template <size_t Dim, typename Frame>
 struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
                                      db::ComputeTag {
   using base = Tags::CharacteristicFields<Dim, Frame>;
@@ -148,19 +176,12 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
       const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
       const tnsr::aa<DataVector, Dim, Frame>& pi,
       const tnsr::iaa<DataVector, Dim, Frame>& phi,
-      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
+    return characteristic_fields(gamma_2, inverse_spatial_metric,
+                                 spacetime_metric, pi, phi,
+                                 unit_normal_one_form);
+  };
 };
-
-template <size_t Dim, typename Frame>
-void compute_characteristic_fields(
-    gsl::not_null<typename Tags::CharacteristicFields<Dim, Frame>::type*>
-        char_fields,
-    const Scalar<DataVector>& gamma_2,
-    const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
-    const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
-    const tnsr::aa<DataVector, Dim, Frame>& pi,
-    const tnsr::iaa<DataVector, Dim, Frame>& phi,
-    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
 // @}
 
 // @{
@@ -169,6 +190,28 @@ void compute_characteristic_fields(
  * \brief For expressions used here to compute evolved fields from
  * characteristic ones, see \ref CharacteristicFieldsCompute.
  */
+template <size_t Dim, typename Frame>
+typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type
+evolved_fields_from_characteristic_fields(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& u_psi,
+    const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
+    const tnsr::aa<DataVector, Dim, Frame>& u_plus,
+    const tnsr::aa<DataVector, Dim, Frame>& u_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+
+template <size_t Dim, typename Frame>
+void evolved_fields_from_characteristic_fields(
+    gsl::not_null<
+        typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type*>
+        evolved_fields,
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& u_psi,
+    const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
+    const tnsr::aa<DataVector, Dim, Frame>& u_plus,
+    const tnsr::aa<DataVector, Dim, Frame>& u_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+
 template <size_t Dim, typename Frame>
 struct EvolvedFieldsFromCharacteristicFieldsCompute
     : Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>,
@@ -187,21 +230,11 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
       const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
       const tnsr::aa<DataVector, Dim, Frame>& u_plus,
       const tnsr::aa<DataVector, Dim, Frame>& u_minus,
-      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
+    return evolved_fields_from_characteristic_fields(
+        gamma_2, u_psi, u_zero, u_plus, u_minus, unit_normal_one_form);
+  };
 };
-
-template <size_t Dim, typename Frame>
-void compute_evolved_fields_from_characteristic_fields(
-    gsl::not_null<
-        typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type*>
-        evolved_fields,
-    const Scalar<DataVector>& gamma_2,
-    const tnsr::aa<DataVector, Dim, Frame>& u_psi,
-    const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
-    const tnsr::aa<DataVector, Dim, Frame>& u_plus,
-    const tnsr::aa<DataVector, Dim, Frame>& u_minus,
-    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
-
 // @}
 
 /*!

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -1,6 +1,5 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
-
 #include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
 
 #include <array>
@@ -8,9 +7,36 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+template <typename TagsList>
+class Variables;
 
 // IWYU pragma: no_forward_declare Tensor
+namespace {
+template <typename FieldTag>
+db::item_type<FieldTag> weight_char_field(
+    const db::item_type<FieldTag>& char_field_int,
+    const DataVector& char_speed_int,
+    const db::item_type<FieldTag>& char_field_ext,
+    const DataVector& char_speed_ext) noexcept {
+  const DataVector& char_speed_avg{0.5 * (char_speed_int + char_speed_ext)};
+  db::item_type<FieldTag> weighted_char_field = char_field_int;
+  auto weighted_char_field_it = weighted_char_field.begin();
+  for (auto int_it = char_field_int.begin(), ext_it = char_field_ext.begin();
+       int_it != char_field_int.end();
+       ++int_it, ++ext_it, ++weighted_char_field_it) {
+    *weighted_char_field_it *= char_speed_avg * step_function(char_speed_avg);
+    *weighted_char_field_it +=
+        char_speed_avg * step_function(-char_speed_avg) * *ext_it;
+  }
+
+  return weighted_char_field;
+}
+}  // namespace
 
 namespace GeneralizedHarmonic {
 
@@ -307,6 +333,178 @@ void ComputeNormalDotFluxes<Dim>::apply(
     }
   }
 }
+
+template <size_t Dim>
+void UpwindFlux<Dim>::package_data(
+    gsl::not_null<Variables<package_tags>*> packaged_data,
+    const db::item_type<
+        gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>&
+        spacetime_metric,
+    const db::item_type<Tags::Pi<Dim, Frame::Inertial>>& pi,
+    const db::item_type<Tags::Phi<Dim, Frame::Inertial>>& phi,
+    const db::item_type<gr::Tags::Lapse<DataVector>>& lapse,
+    const db::item_type<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>&
+        shift,
+    const db::item_type<
+        gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>&
+        inverse_spatial_metric,
+    const db::item_type<Tags::ConstraintGamma1>& gamma1,
+    const db::item_type<Tags::ConstraintGamma2>& gamma2,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+    const noexcept {
+  get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
+      *packaged_data) = spacetime_metric;
+  get<Tags::Pi<Dim, Frame::Inertial>>(*packaged_data) = pi;
+  get<Tags::Phi<Dim, Frame::Inertial>>(*packaged_data) = phi;
+  get<gr::Tags::Lapse<DataVector>>(*packaged_data) = lapse;
+  get<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>(*packaged_data) =
+      shift;
+  get<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>(
+      *packaged_data) = inverse_spatial_metric;
+  get<Tags::ConstraintGamma1>(*packaged_data) = gamma1;
+  get<Tags::ConstraintGamma2>(*packaged_data) = gamma2;
+  get<::Tags::UnitFaceNormal<Dim, Frame::Inertial>>(*packaged_data) =
+      interface_unit_normal;
+}
+
+template <size_t Dim>
+void UpwindFlux<Dim>::operator()(
+    gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+        gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>>*>
+        psi_normal_dot_numerical_flux,
+    gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+        GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>>*>
+        pi_normal_dot_numerical_flux,
+    gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+        GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>>>*>
+        phi_normal_dot_numerical_flux,
+    const db::item_type<
+        gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>&
+        spacetime_metric_int,
+    const db::item_type<Tags::Pi<Dim, Frame::Inertial>>& pi_int,
+    const db::item_type<Tags::Phi<Dim, Frame::Inertial>>& phi_int,
+    const db::item_type<gr::Tags::Lapse<DataVector>>& lapse_int,
+    const db::item_type<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>&
+        shift_int,
+    const db::item_type<
+        gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>&
+        inverse_spatial_metric_int,
+    const db::item_type<Tags::ConstraintGamma2>& gamma1_int,
+    const db::item_type<Tags::ConstraintGamma2>& gamma2_int,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal_int,
+    const db::item_type<
+        gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>&
+        spacetime_metric_ext,
+    const db::item_type<Tags::Pi<Dim, Frame::Inertial>>& pi_ext,
+    const db::item_type<Tags::Phi<Dim, Frame::Inertial>>& phi_ext,
+    const db::item_type<gr::Tags::Lapse<DataVector>>& lapse_ext,
+    const db::item_type<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>&
+        shift_ext,
+    const db::item_type<
+        gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>&
+        inverse_spatial_metric_ext,
+    const db::item_type<Tags::ConstraintGamma2>& gamma1_ext,
+    const db::item_type<Tags::ConstraintGamma2>& gamma2_ext,
+    const tnsr::i<DataVector, Dim,
+                  Frame::Inertial>& /*interface_unit_normal_ext*/) const
+    noexcept {
+  const Scalar<DataVector> gamma1_avg{0.5 *
+                                      (get(gamma1_int) + get(gamma1_ext))};
+  const Scalar<DataVector> gamma2_avg{0.5 *
+                                      (get(gamma2_int) + get(gamma2_ext))};
+
+  const auto& char_fields_int = characteristic_fields(
+      gamma2_avg, inverse_spatial_metric_int, spacetime_metric_int, pi_int,
+      phi_int, interface_unit_normal_int);
+  const auto& char_speeds_int = characteristic_speeds(
+      gamma1_avg, lapse_int, shift_int, interface_unit_normal_int);
+  const auto& char_fields_ext = characteristic_fields(
+      gamma2_avg, inverse_spatial_metric_ext, spacetime_metric_ext, pi_ext,
+      phi_ext, interface_unit_normal_int);
+  const auto& char_speeds_ext = characteristic_speeds(
+      gamma1_avg, lapse_ext, shift_ext, interface_unit_normal_int);
+
+  const auto& weighted_char_fields = weight_char_fields(
+      char_fields_int, char_speeds_int, char_fields_ext, char_speeds_ext);
+
+  const auto& weighted_evolved_fields =
+      evolved_fields_from_characteristic_fields(
+          gamma2_avg,
+          get<Tags::UPsi<Dim, Frame::Inertial>>(weighted_char_fields),
+          get<Tags::UZero<Dim, Frame::Inertial>>(weighted_char_fields),
+          get<Tags::UPlus<Dim, Frame::Inertial>>(weighted_char_fields),
+          get<Tags::UMinus<Dim, Frame::Inertial>>(weighted_char_fields),
+          interface_unit_normal_int);
+
+  *psi_normal_dot_numerical_flux =
+      get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial>>(
+          weighted_evolved_fields);
+  *pi_normal_dot_numerical_flux =
+      get<Tags::Pi<Dim, Frame::Inertial>>(weighted_evolved_fields);
+  *phi_normal_dot_numerical_flux =
+      get<Tags::Phi<Dim, Frame::Inertial>>(weighted_evolved_fields);
+}
+
+template <size_t Dim>
+db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>
+UpwindFlux<Dim>::weight_char_fields(
+    const db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
+        char_fields_int,
+    const db::item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
+        char_speeds_int,
+    const db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
+        char_fields_ext,
+    const db::item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
+        char_speeds_ext) const noexcept {
+  const auto& u_psi_int =
+      get<Tags::UPsi<Dim, Frame::Inertial>>(char_fields_int);
+  const auto& u_zero_int =
+      get<Tags::UZero<Dim, Frame::Inertial>>(char_fields_int);
+  const auto& u_plus_int =
+      get<Tags::UPlus<Dim, Frame::Inertial>>(char_fields_int);
+  const auto& u_minus_int =
+      get<Tags::UMinus<Dim, Frame::Inertial>>(char_fields_int);
+
+  const DataVector& char_speed_u_psi_int{char_speeds_int[0]};
+  const DataVector& char_speed_u_zero_int{char_speeds_int[1]};
+  const DataVector& char_speed_u_plus_int{char_speeds_int[2]};
+  const DataVector& char_speed_u_minus_int{char_speeds_int[3]};
+
+  const auto& u_psi_ext =
+      get<Tags::UPsi<Dim, Frame::Inertial>>(char_fields_ext);
+  const auto& u_zero_ext =
+      get<Tags::UZero<Dim, Frame::Inertial>>(char_fields_ext);
+  const auto& u_plus_ext =
+      get<Tags::UPlus<Dim, Frame::Inertial>>(char_fields_ext);
+  const auto& u_minus_ext =
+      get<Tags::UMinus<Dim, Frame::Inertial>>(char_fields_ext);
+
+  const DataVector& char_speed_u_psi_ext{char_speeds_ext[0]};
+  const DataVector& char_speed_u_zero_ext{char_speeds_ext[1]};
+  const DataVector& char_speed_u_plus_ext{char_speeds_ext[2]};
+  const DataVector& char_speed_u_minus_ext{char_speeds_ext[3]};
+
+  auto weighted_char_fields = make_with_value<
+      db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>>(
+      char_speed_u_psi_int, 0.0);
+
+  get<Tags::UPsi<Dim, Frame::Inertial>>(weighted_char_fields) =
+      weight_char_field<GeneralizedHarmonic::Tags::UPsi<Dim, Frame::Inertial>>(
+          u_psi_int, char_speed_u_psi_int, u_psi_ext, char_speed_u_psi_ext);
+  get<Tags::UZero<Dim, Frame::Inertial>>(weighted_char_fields) =
+      weight_char_field<GeneralizedHarmonic::Tags::UZero<Dim, Frame::Inertial>>(
+          u_zero_int, char_speed_u_zero_int, u_zero_ext, char_speed_u_zero_ext);
+  get<Tags::UPlus<Dim, Frame::Inertial>>(weighted_char_fields) =
+      weight_char_field<GeneralizedHarmonic::Tags::UPlus<Dim, Frame::Inertial>>(
+          u_plus_int, char_speed_u_plus_int, u_plus_ext, char_speed_u_plus_ext);
+  get<Tags::UMinus<Dim, Frame::Inertial>>(weighted_char_fields) =
+      weight_char_field<
+          GeneralizedHarmonic::Tags::UMinus<Dim, Frame::Inertial>>(
+          u_minus_int, char_speed_u_minus_int, u_minus_ext,
+          char_speed_u_minus_ext);
+
+  return weighted_char_fields;
+}
 /// \endcond
 }  // namespace GeneralizedHarmonic
 
@@ -317,3 +515,7 @@ template struct GeneralizedHarmonic::ComputeDuDt<3>;
 template struct GeneralizedHarmonic::ComputeNormalDotFluxes<1>;
 template struct GeneralizedHarmonic::ComputeNormalDotFluxes<2>;
 template struct GeneralizedHarmonic::ComputeNormalDotFluxes<3>;
+
+template struct GeneralizedHarmonic::UpwindFlux<1>;
+template struct GeneralizedHarmonic::UpwindFlux<2>;
+template struct GeneralizedHarmonic::UpwindFlux<3>;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -290,15 +290,13 @@ void ComputeNormalDotFluxes<Dim>::apply(
     const tnsr::i<DataVector, Dim>& unit_normal) noexcept {
   const auto shift_dot_normal = get(dot_product(shift, unit_normal));
 
-  auto normal_dot_phi =
-      make_with_value<tnsr::aa<DataVector, Dim>>(gamma1, 0.);
+  auto normal_dot_phi = make_with_value<tnsr::aa<DataVector, Dim>>(gamma1, 0.);
   for (size_t mu = 0; mu < Dim + 1; ++mu) {
     for (size_t nu = mu; nu < Dim + 1; ++nu) {
       for (size_t i = 0; i < Dim; ++i) {
         for (size_t j = 0; j < Dim; ++j) {
           normal_dot_phi.get(mu, nu) += inverse_spatial_metric.get(i, j) *
-                                              unit_normal.get(j) *
-                                              phi.get(i, mu, nu);
+                                        unit_normal.get(j) * phi.get(i, mu, nu);
         }
       }
     }
@@ -363,8 +361,8 @@ void UpwindFlux<Dim>::package_data(
       *packaged_data) = inverse_spatial_metric;
   get<Tags::ConstraintGamma1>(*packaged_data) = gamma1;
   get<Tags::ConstraintGamma2>(*packaged_data) = gamma2;
-  get<::Tags::UnitFaceNormal<Dim, Frame::Inertial>>(*packaged_data) =
-      interface_unit_normal;
+  get<::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>(
+      *packaged_data) = interface_unit_normal;
 }
 
 template <size_t Dim>

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -8,27 +8,44 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"  // IWYU pragma: keep
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace Tags {
-template <typename>
-class dt;
-template <typename>
-struct NormalDotFlux;
+template <typename Tag>
+struct NormalDotNumericalFlux;
+
+template <typename Tag>
+struct Normalized;
 }  // namespace Tags
 
 namespace gsl {
 template <class T>
 class not_null;
 }  // namespace gsl
+
+template <typename TagsList>
+class Variables;
+
+template <typename, typename, typename>
+class Tensor;
 /// \endcond
+
+// IWYU pragma: no_forward_declare Tags::deriv
 
 namespace GeneralizedHarmonic {
 /*!
@@ -108,11 +125,11 @@ struct ComputeDuDt {
 template <size_t Dim>
 struct ComputeNormalDotFluxes {
  public:
-  using argument_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
-                 Tags::ConstraintGamma1, Tags::ConstraintGamma2,
-                 gr::Tags::Lapse<>, gr::Tags::Shift<Dim>,
-                 gr::Tags::InverseSpatialMetric<Dim>>;
+  using argument_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
+      Tags::ConstraintGamma1, Tags::ConstraintGamma2, gr::Tags::Lapse<>,
+      gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*>
@@ -126,5 +143,168 @@ struct ComputeNormalDotFluxes {
       const tnsr::I<DataVector, Dim>& shift,
       const tnsr::II<DataVector, Dim>& inverse_spatial_metric,
       const tnsr::i<DataVector, Dim>& unit_normal) noexcept;
+};
+
+/*!
+ * \ingroup NumericalFluxesGroup
+ * \brief Computes the generalized-harmonic upwind flux
+ *
+ * The upwind flux in general is given by Eq. (6.3) of \cite Teukolsky2015ega :
+ * \f{eqnarray}{
+ * F^* = S \Lambda^+ S^{-1} u^- + S \Lambda^- S^{-1} u^+,
+ * \f}
+ * where \f$u\f$ is a vector of the evolved variables, \f$S^{-1}\f$
+ * maps the evolved variables into the characteristic variables \f$S^{-1}u\f$,
+ * \f$S\f$ maps the characteristic variables into the evolved variables,
+ * and \f$\Lambda\f$ is a diagonal matrix of the average characteristic
+ * speed at the interface.
+ *
+ * Here, \f$S^{-1}u^-\f$ represents the
+ * characteristic variables at the element interface, computed using
+ * evolved variables from the element interior;
+ * \f$S^{-1}u^+\f$ represents the characteristic variables at the element
+ * interface, computed using evolved variables from the exterior, neighboring
+ * element; \f$\Lambda^+\f$ is a diagonal
+ * matrix whose nonzero entries are the average characteristic speeds
+ * that are positive ("outgoing", i.e. leaving the element); and
+ * \f$\Lambda^-\f$ is a diagonal matrix whose nonzero entries are the average
+ * characteristic speeds that are negative ("incoming", i.e. entering the
+ * element). If a characteristic field
+ * \f$U^-\f$ has a characteristic speed \f$v^-\f$ and the same
+ * field in the exterior \f$U^+\f$ has speed \f$v^+\f$, then the
+ * average characteristic speed is \f$v^{\rm avg} = (1/2)(v^- + v^+)\f$.
+ *
+ * This function implements the upwind flux for the generalized harmonic
+ * system. First, it computes the characteristic variables using i) the
+ * evolved variables from the interior and ii) the evolved variables from the
+ * exterior. Then, it computes \f$\Lambda^+\f$ and \f$\Lambda^-\f$
+ * from the average characteristic speeds. Then, it computes the
+ * combination \f$\Lambda^+ S^{-1} u^- + \Lambda^- S^{-1} u^+\f$. Finally, it
+ * applies \f$S\f$ by converting the result back from characteristic to
+ * evolved variables, using the unit normal vector of the element and
+ * the average value of the field
+ * \f$\gamma_2^{\rm avg} = (1/2)(\gamma_2^- + \gamma_2^+)\f$, where here
+ * \f$\gamma_2^-\f$ is the value of \f$\gamma_2\f$ in the interior and
+ * \f$\gamma_2^+\f$ is the vaule of \f$\gamma_2\f$ in the exterior.
+ */
+template <size_t Dim>
+struct UpwindFlux {
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+      "Computes the generalized harmonic upwind flux. It requires no "
+      "options."};
+
+  // clang-tidy: non-const reference
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+
+  // This is the data needed to compute the numerical flux.
+  // `dg::SendBoundaryFluxes` calls `package_data` to store these tags in a
+  // Variables. Local and remote values of this data are then combined in the
+  // `()` operator.
+  using package_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::Pi<Dim, Frame::Inertial>, Tags::Phi<Dim, Frame::Inertial>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+      ::Tags::UnitFaceNormal<Dim, Frame::Inertial>>;
+
+  // These tags on the interface of the element are passed to
+  // `package_data` to provide the data needed to compute the numerical fluxes.
+  using argument_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::Pi<Dim, Frame::Inertial>, Tags::Phi<Dim, Frame::Inertial>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+      ::Tags::UnitFaceNormal<Dim, Frame::Inertial>>;
+
+  // pseudo-interface: used internally by Algorithm infrastructure, not
+  // user-level code
+  // Following the not-null pointer to packaged_data, this function expects as
+  // arguments the databox types of the `argument_tags`.
+  void package_data(
+      gsl::not_null<Variables<package_tags>*> packaged_data,
+      const db::item_type<
+          gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>&
+          spacetime_metric,
+      const db::item_type<Tags::Pi<Dim, Frame::Inertial>>& pi,
+      const db::item_type<Tags::Phi<Dim, Frame::Inertial>>& phi,
+      const db::item_type<gr::Tags::Lapse<DataVector>>& lapse,
+      const db::item_type<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>&
+          shift,
+      const db::item_type<
+          gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>&
+          inverse_spatial_metric,
+      const db::item_type<Tags::ConstraintGamma1>& gamma1,
+      const db::item_type<Tags::ConstraintGamma2>& gamma2,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+      const noexcept;
+
+  // pseudo-interface: used internally by Algorithm infrastructure, not
+  // user-level code
+  // The arguments are first the system::variables_tag::tags_list wrapped in
+  // Tags::NormalDotNumericalFlux as not-null pointers to write the results
+  // into, then the package_tags on the interior side of the mortar followed by
+  // the package_tags on the exterior side.
+  void operator()(
+      gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+          gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>>*>
+          psi_normal_dot_numerical_flux,
+      gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+          GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>>*>
+          pi_normal_dot_numerical_flux,
+      gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
+          GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>>>*>
+          phi_normal_dot_numerical_flux,
+      const db::item_type<
+          gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>&
+          spacetime_metric_int,
+      const db::item_type<Tags::Pi<Dim, Frame::Inertial>>& pi_int,
+      const db::item_type<Tags::Phi<Dim, Frame::Inertial>>& phi_int,
+      const db::item_type<gr::Tags::Lapse<DataVector>>& lapse_int,
+      const db::item_type<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>&
+          shift_int,
+      const db::item_type<
+          gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>&
+          inverse_spatial_metric_int,
+      const db::item_type<Tags::ConstraintGamma2>& gamma1_int,
+      const db::item_type<Tags::ConstraintGamma2>& gamma2_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          interface_unit_normal_int,
+      const db::item_type<
+          gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>&
+          spacetime_metric_ext,
+      const db::item_type<Tags::Pi<Dim, Frame::Inertial>>& pi_ext,
+      const db::item_type<Tags::Phi<Dim, Frame::Inertial>>& phi_ext,
+      const db::item_type<gr::Tags::Lapse<DataVector>>& lapse_ext,
+      const db::item_type<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>&
+          shift_ext,
+      const db::item_type<
+          gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>&
+          inverse_spatial_metric_ext,
+      const db::item_type<Tags::ConstraintGamma2>& gamma1_ext,
+      const db::item_type<Tags::ConstraintGamma2>& gamma2_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          interface_unit_normal_ext) const noexcept;
+
+  // Function that performs the upwind weighting. Inputs are the char fields
+  // and speeds in the interior and exterior. At each point, each returned
+  // field is the product of the interior char field and its char speed
+  // (if the char speed is outgoing) or the product of the exterior char field
+  // and its char speed (if the char speed is incoming).
+  db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>
+  weight_char_fields(
+      const db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
+          char_fields_int,
+      const db::item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
+          char_speeds_int,
+      const db::item_type<Tags::CharacteristicFields<Dim, Frame::Inertial>>&
+          char_fields_ext,
+      const db::item_type<Tags::CharacteristicSpeeds<Dim, Frame::Inertial>>&
+          char_speeds_ext) const noexcept;
 };
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -209,7 +209,7 @@ struct UpwindFlux {
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
       Tags::ConstraintGamma1, Tags::ConstraintGamma2,
-      ::Tags::UnitFaceNormal<Dim, Frame::Inertial>>;
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
 
   // These tags on the interface of the element are passed to
   // `package_data` to provide the data needed to compute the numerical fluxes.
@@ -220,7 +220,7 @@ struct UpwindFlux {
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
       Tags::ConstraintGamma1, Tags::ConstraintGamma2,
-      ::Tags::UnitFaceNormal<Dim, Frame::Inertial>>;
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -1,0 +1,319 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>  // IWYU pragma: keep
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Domain.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/GeneralizedHarmonicInterface.hpp"
+#include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+namespace detail {
+template <class T, class = cpp17::void_t<>>
+struct has_analytic_solution_alias : std::false_type {};
+template <class T>
+struct has_analytic_solution_alias<
+    T, cpp17::void_t<typename T::analytic_solution_tag>> : std::true_type {};
+}  // namespace detail
+
+// Note:  I've left the Dim and System template parameters until it is clear
+// whether or not what remains is specific to this system, and what might be
+// applicable to more than one system
+template <size_t Dim>
+struct Initialize {
+  template <typename Metavariables>
+  struct ConstraintsTags {
+    using Inertial = Frame::Inertial;
+    using simple_tags = db::AddSimpleTags<>;
+    using compute_tags = db::AddComputeTags<
+        GeneralizedHarmonic::Tags::FConstraintCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::ConstraintEnergyCompute<Dim, Inertial>>;
+    template <typename TagsList>
+    static auto initialize(db::DataBox<TagsList>&& box) noexcept {
+      return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+          std::move(box));
+    }
+  };
+
+  template <typename Metavariables>
+  struct VariablesTags {
+    using Inertial = Frame::Inertial;
+    using system = typename Metavariables::system;
+    using variables_tag = typename system::variables_tag;
+    using extras_tag = typename system::extras_tag;
+
+    using simple_tags = db::AddSimpleTags<
+        variables_tag, extras_tag,
+        ::Tags::dt<GeneralizedHarmonic::Tags::GaugeH<Dim, Inertial>>>;
+    using compute_tags = db::AddComputeTags<
+        gr::Tags::SpatialMetricCompute<Dim, Inertial, DataVector>,
+        gr::Tags::DetAndInverseSpatialMetricCompute<Dim, Inertial, DataVector>,
+        gr::Tags::DetSpatialMetricCompute<Dim, Inertial, DataVector>,
+        gr::Tags::InverseSpatialMetricCompute<Dim, Inertial, DataVector>,
+        gr::Tags::ShiftCompute<Dim, Inertial, DataVector>,
+        gr::Tags::LapseCompute<Dim, Inertial, DataVector>,
+        gr::Tags::SqrtDetSpatialMetricCompute<Dim, Inertial, DataVector>,
+        gr::Tags::SpacetimeNormalOneFormCompute<Dim, Inertial, DataVector>,
+        gr::Tags::SpacetimeNormalVectorCompute<Dim, Inertial, DataVector>,
+        gr::Tags::InverseSpacetimeMetricCompute<Dim, Inertial, DataVector>,
+        GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::DerivLapseCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::DerivShiftCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::TimeDerivLapseCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::TimeDerivShiftCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::DerivativesOfSpacetimeMetricCompute<
+            Dim, Inertial>,
+        GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, Inertial>,
+        gr::Tags::SpacetimeChristoffelFirstKindCompute<Dim, Inertial,
+                                                       DataVector>,
+        gr::Tags::SpacetimeChristoffelSecondKindCompute<Dim, Inertial,
+                                                        DataVector>,
+        gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<Dim, Inertial,
+                                                            DataVector>,
+        gr::Tags::SpatialChristoffelFirstKindCompute<Dim, Inertial, DataVector>,
+        gr::Tags::SpatialChristoffelSecondKindCompute<Dim, Inertial,
+                                                      DataVector>,
+        gr::Tags::TraceSpatialChristoffelFirstKindCompute<Dim, Inertial,
+                                                          DataVector>,
+        GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<Dim,
+                                                                  Inertial>,
+        GeneralizedHarmonic::Tags::ConstraintGamma0Compute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::ConstraintGamma1Compute<Dim, Inertial>,
+        GeneralizedHarmonic::Tags::ConstraintGamma2Compute<Dim, Inertial>,
+        // Because DerivCompute<GaugeH> operates on GaugeH wrapped in a
+        // Variables container, we insert GaugeH that way into the box (below),
+        // instead of directly adding GaugeHCompute tag here.
+        ::Tags::DerivCompute<
+            ::Tags::Variables<
+                tmpl::list<GeneralizedHarmonic::Tags::GaugeH<Dim, Inertial>>>,
+            ::Tags::InverseJacobian<::Tags::ElementMap<Dim, Inertial>,
+                                    ::Tags::LogicalCoordinates<Dim>>>,
+        GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<Dim, Inertial>,
+        // GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim,
+        // Inertial>,
+        GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, Inertial>>;
+
+    template <typename TagsList>
+    static auto initialize(
+        db::DataBox<TagsList>&& box,
+        const Parallel::ConstGlobalCache<Metavariables>& cache,
+        const double initial_time) noexcept {
+      const size_t num_grid_points =
+          db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points();
+      const auto& inertial_coords =
+          db::get<::Tags::Coordinates<Dim, Inertial>>(box);
+
+      // Set initial data from analytic solution
+      using Vars = typename variables_tag::type;
+      Vars vars{num_grid_points};
+      typename GeneralizedHarmonic::Tags::GaugeH<Dim, Inertial>::type
+          gauge_source{num_grid_points};
+      make_overloader([ initial_time, &inertial_coords, &gauge_source ](
+                          std::true_type /*is_analytic_solution*/,
+                          const gsl::not_null<Vars*> local_vars,
+                          const auto& local_cache) noexcept {
+        using analytic_solution_tag = OptionTags::AnalyticSolutionBase;
+        /*
+         * It is assumed here that the analytic solution makes available the
+         * tags listed in gr::analytic_solution_tags
+         */
+        const auto& solution_vars =
+            Parallel::get<analytic_solution_tag>(local_cache)
+                .variables(inertial_coords, initial_time,
+                           gr::analytic_solution_tags<Dim, DataVector>{});
+        // First fetch lapse, shift, spatial metric and their derivs
+        const auto& lapse = get<gr::Tags::Lapse<DataVector>>(solution_vars);
+        const auto& dt_lapse =
+            get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(solution_vars);
+        const auto& deriv_lapse =
+            get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                              Inertial>>(solution_vars);
+
+        const auto& shift =
+            get<gr::Tags::Shift<Dim, Inertial, DataVector>>(solution_vars);
+        const auto& dt_shift =
+            get<::Tags::dt<gr::Tags::Shift<Dim, Inertial, DataVector>>>(
+                solution_vars);
+        const auto& deriv_shift =
+            get<::Tags::deriv<gr::Tags::Shift<Dim, Inertial, DataVector>,
+                              tmpl::size_t<Dim>, Inertial>>(solution_vars);
+
+        const auto& spatial_metric =
+            get<gr::Tags::SpatialMetric<Dim, Inertial, DataVector>>(
+                solution_vars);
+        const auto& dt_spatial_metric =
+            get<::Tags::dt<gr::Tags::SpatialMetric<Dim, Inertial, DataVector>>>(
+                solution_vars);
+        const auto& deriv_spatial_metric = get<
+            ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Inertial, DataVector>,
+                          tmpl::size_t<Dim>, Inertial>>(solution_vars);
+
+        // Next, compute Gh evolution variables from them
+        const auto& spacetime_metric =
+            ::gr::spacetime_metric<Dim, Inertial, DataVector>(lapse, shift,
+                                                              spatial_metric);
+        const auto& phi = GeneralizedHarmonic::phi<Dim, Inertial, DataVector>(
+            lapse, deriv_lapse, shift, deriv_shift, spatial_metric,
+            deriv_spatial_metric);
+        const auto& pi = GeneralizedHarmonic::pi<Dim, Inertial, DataVector>(
+            lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric,
+            phi);
+
+        const tuples::TaggedTuple<gr::Tags::SpacetimeMetric<Dim>,
+                                  GeneralizedHarmonic::Tags::Phi<Dim>,
+                                  GeneralizedHarmonic::Tags::Pi<Dim>>
+            solution_tuple(spacetime_metric, phi, pi);
+
+        local_vars->assign_subset(solution_tuple);
+
+        // Compute the initial gauge source function
+        // 1. Trace of extrinsic curvature
+        const auto& extrinsic_curvature =
+            get<gr::Tags::ExtrinsicCurvature<Dim, Inertial, DataVector>>(
+                solution_vars);
+        const auto& inverse_spatial_metric =
+            get<gr::Tags::InverseSpatialMetric<Dim, Inertial, DataVector>>(
+                solution_vars);
+        const auto& trace_extrinsic_curvature =
+            trace(extrinsic_curvature, inverse_spatial_metric);
+        // 2. Trace of Christoffel
+        const auto& spatial_christoffel_first_kind =
+            gr::Tags::SpatialChristoffelFirstKindCompute<
+                Dim, Inertial, DataVector>::function(deriv_spatial_metric);
+        const auto& trace_christoffel_last_indices =
+            gr::Tags::TraceSpatialChristoffelFirstKindCompute<
+                Dim, Inertial,
+                DataVector>::function(spatial_christoffel_first_kind,
+                                      inverse_spatial_metric);
+        // 3. Call the compute item for the gauge source function
+        gauge_source =
+            GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
+                Dim, Inertial>::function(lapse, dt_lapse, deriv_lapse, shift,
+                                         dt_shift, deriv_shift, spatial_metric,
+                                         trace_extrinsic_curvature,
+                                         trace_christoffel_last_indices);
+      },
+                      [&inertial_coords](
+                          std::false_type /*is_analytic_solution*/,
+                          const gsl::not_null<Vars*> local_vars,
+                          const auto& local_cache) noexcept {
+                        ASSERT(false, "Analytic Solution does not work yet.");
+                        using analytic_data_tag = OptionTags::AnalyticDataBase;
+                        local_vars->assign_subset(
+                            Parallel::get<analytic_data_tag>(local_cache)
+                                .variables(inertial_coords,
+                                           typename Vars::tags_list{}));
+                      })(detail::has_analytic_solution_alias<Metavariables>{},
+                         make_not_null(&vars), cache);
+
+      // Set the time derivatives of GaugeH
+      const auto& dt_gauge_source =
+          make_with_value<tnsr::a<DataVector, Dim, Inertial>>(inertial_coords,
+                                                              0.);
+
+      using ExtraVars = typename extras_tag::type;
+      ExtraVars extra_vars{num_grid_points};
+      get<GeneralizedHarmonic::Tags::GaugeH<Dim, Inertial>>(extra_vars) =
+          gauge_source;
+
+      return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+          std::move(box), std::move(vars), std::move(extra_vars),
+          std::move(dt_gauge_source));
+    }
+  };
+
+  template <class Metavariables>
+  using return_tag_list =
+      tmpl::append<typename Initialization::Domain<Dim>::simple_tags,
+                   typename VariablesTags<Metavariables>::simple_tags,
+                   typename Initialization::GeneralizedHarmonicInterface<
+                       typename Metavariables::system>::simple_tags,
+                   typename Initialization::Evolution<
+                       typename Metavariables::system>::simple_tags,
+                   typename ConstraintsTags<Metavariables>::simple_tags,
+                   typename Initialization::DiscontinuousGalerkin<
+                       Metavariables>::simple_tags,
+                   typename Initialization::MinMod<Dim>::simple_tags,
+                   typename Initialization::Domain<Dim>::compute_tags,
+                   typename VariablesTags<Metavariables>::compute_tags,
+                   typename Initialization::GeneralizedHarmonicInterface<
+                       typename Metavariables::system>::compute_tags,
+                   typename Initialization::Evolution<
+                       typename Metavariables::system>::compute_tags,
+                   typename ConstraintsTags<Metavariables>::compute_tags,
+                   typename Initialization::DiscontinuousGalerkin<
+                       Metavariables>::compute_tags,
+                   typename Initialization::MinMod<Dim>::compute_tags>;
+
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    std::vector<std::array<size_t, Dim>> initial_extents,
+                    Domain<Dim, Frame::Inertial> domain,
+                    const double initial_time, const double initial_dt,
+                    const double initial_slab_size) noexcept {
+    using system = typename Metavariables::system;
+    auto domain_box = Initialization::Domain<Dim>::initialize(
+        db::DataBox<tmpl::list<>>{}, array_index, initial_extents, domain);
+    auto variables_box = VariablesTags<Metavariables>::initialize(
+        std::move(domain_box), cache, initial_time);
+    auto domain_interface_box =
+        Initialization::GeneralizedHarmonicInterface<system>::initialize(
+            std::move(variables_box));
+    auto evolution_box = Initialization::Evolution<system>::initialize(
+        std::move(domain_interface_box), cache, initial_time, initial_dt,
+        initial_slab_size);
+    auto constraints_box =
+        ConstraintsTags<Metavariables>::initialize(std::move(evolution_box));
+    auto dg_box =
+        Initialization::DiscontinuousGalerkin<Metavariables>::initialize(
+            std::move(constraints_box), initial_extents);
+    auto limiter_box =
+        Initialization::MinMod<Dim>::initialize(std::move(dg_box));
+    return std::make_tuple(std::move(limiter_box));
+  }
+};
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Observe.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Observe.hpp
@@ -1,0 +1,281 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "IO/Observer/Actions.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace GeneralizedHarmonic {
+namespace Actions {
+
+namespace observe_detail {}  // namespace observe_detail
+
+/*!
+ * \brief Temporary action for observing volume and reduction data
+ *
+ * A few notes:
+ * - Writes the solution and error in \f$\Psi_{ab}, \Pi_{ab}\f$, and
+ * \f$\Phi_{iab}\f$ to disk as volume data.
+ * - The RMS error of \f$\Psi\f$ and \f$\Pi\f$ are written to disk.
+ */
+struct Observe {
+ private:
+  using reduction_datum =
+      Parallel::ReductionDatum<double, funcl::Plus<>,
+                               funcl::Sqrt<funcl::Divides<>>,
+                               std::index_sequence<1>>;
+  using reduction_data = Parallel::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>, reduction_datum,
+      reduction_datum, reduction_datum, reduction_datum, reduction_datum,
+      reduction_datum, reduction_datum, reduction_datum>;
+
+ public:
+  struct ObserveNSlabs {
+    using type = size_t;
+    static constexpr OptionString help = {"Observe every Nth slab"};
+  };
+  struct ObserveAtT0 {
+    using type = bool;
+    static constexpr OptionString help = {"If true observe at t=0"};
+  };
+
+  using const_global_cache_tags = tmpl::list<ObserveNSlabs, ObserveAtT0>;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<reduction_data>>;
+
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const auto& time_id = db::get<::Tags::TimeId>(box);
+    if (time_id.substep() != 0 or (time_id.slab_number() == 0 and
+                                   not Parallel::get<ObserveAtT0>(cache))) {
+      return std::forward_as_tuple(std::move(box));
+    }
+
+    const auto& time = time_id.time();
+    const std::string element_name = MakeString{} << ElementId<Dim>(array_index)
+                                                  << '/';
+
+    if (time_id.slab_number() >= 0 and time_id.time().is_at_slab_start() and
+        static_cast<size_t>(time_id.slab_number()) %
+                Parallel::get<ObserveNSlabs>(cache) ==
+            0) {
+      const auto& extents = db::get<::Tags::Mesh<Dim>>(box).extents();
+      const auto& num_grid_points =
+          db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points();
+      // Retrieve the tensors and compute the solution error.
+      const auto& psi =
+          db::get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial>>(box);
+      const auto& phi =
+          db::get<GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>>(box);
+      const auto& pi =
+          db::get<GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>(box);
+      const auto& gauge_constraint = db::get<
+          GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame::Inertial>>(
+          box);
+      const auto& three_index_constraint =
+          db::get<GeneralizedHarmonic::Tags::ThreeIndexConstraint<
+              Dim, Frame::Inertial>>(box);
+      const auto& constraint_energy = db::get<
+          GeneralizedHarmonic::Tags::ConstraintEnergy<Dim, Frame::Inertial>>(
+          box);
+
+      const auto& inertial_coordinates =
+          db::get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+
+      const auto& gauge_H =
+          db::get<GeneralizedHarmonic::Tags::GaugeH<Dim, Frame::Inertial>>(box);
+
+      // Compute the error in the solution, and generate tensor component list.
+      using solution_tag = OptionTags::AnalyticSolutionBase;
+
+      const auto& exact_solution = Parallel::get<solution_tag>(cache);
+
+      const auto& exact_solution_variables = exact_solution.variables(
+          inertial_coordinates, time.value(),
+          gr::analytic_solution_tags<Dim, DataVector>{});
+      const auto& exact_lapse =
+          get<gr::Tags::Lapse<DataVector>>(exact_solution_variables);
+      const auto& exact_dt_lapse = get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(
+          exact_solution_variables);
+      const auto& exact_deriv_lapse =
+          get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                            Frame::Inertial>>(exact_solution_variables);
+      const auto& exact_shift =
+          get<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>(
+              exact_solution_variables);
+      const auto& exact_dt_shift =
+          get<::Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>>(
+              exact_solution_variables);
+      const auto& exact_deriv_shift =
+          get<::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+                            tmpl::size_t<Dim>, Frame::Inertial>>(
+              exact_solution_variables);
+      const auto& exact_spatial_metric =
+          get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>>(
+              exact_solution_variables);
+      const auto& exact_dt_spatial_metric = get<::Tags::dt<
+          gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>>>(
+          exact_solution_variables);
+      const auto& exact_deriv_spatial_metric = get<::Tags::deriv<
+          gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>,
+          tmpl::size_t<Dim>, Frame::Inertial>>(exact_solution_variables);
+
+      const auto& exact_psi =
+          gr::spacetime_metric(exact_lapse, exact_shift, exact_spatial_metric);
+      const auto& exact_phi = GeneralizedHarmonic::phi(
+          exact_lapse, exact_deriv_lapse, exact_shift, exact_deriv_shift,
+          exact_spatial_metric, exact_deriv_spatial_metric);
+      const auto& exact_pi = GeneralizedHarmonic::pi(
+          exact_lapse, exact_dt_lapse, exact_shift, exact_dt_shift,
+          exact_spatial_metric, exact_dt_spatial_metric, exact_phi);
+
+      // Remove tensor types, only storing individual components.
+      std::vector<TensorComponent> components;
+      components.reserve(8);  // FIXME
+
+      using PlusSquare = funcl::Plus<funcl::Identity, funcl::Square<>>;
+
+      // FIX ME: don't copy, just initialize to the right size
+      DataVector error_in_psi_components{num_grid_points, 0.};
+      DataVector error_in_phi_components{num_grid_points, 0.};
+      DataVector error_in_pi_components{num_grid_points, 0.};
+      DataVector gauge_constraint_all_components{num_grid_points, 0.};
+      DataVector three_index_constraint_all_components{num_grid_points, 0.};
+      for (size_t a = 0; a < Dim + 1; ++a) {
+        gauge_constraint_all_components += square(gauge_constraint.get(a));
+        for (size_t b = 0; b < Dim + 1; ++b) {
+          error_in_psi_components +=
+              square(exact_psi.get(a, b) - psi.get(a, b));
+          error_in_pi_components += square(exact_pi.get(a, b) - pi.get(a, b));
+          for (size_t i = 0; i < Dim; ++i) {
+            three_index_constraint_all_components +=
+                square(three_index_constraint.get(i, a, b));
+            error_in_phi_components +=
+                square(exact_phi.get(i, a, b) - phi.get(i, a, b));
+          }
+        }
+      }
+      const double psi_error =
+          alg::accumulate(error_in_psi_components, 0., PlusSquare{});
+      const double phi_error =
+          alg::accumulate(error_in_phi_components, 0., PlusSquare{});
+      const double pi_error =
+          alg::accumulate(error_in_pi_components, 0., PlusSquare{});
+      const double gauge_constraint_cumulative =
+          alg::accumulate(gauge_constraint_all_components, 0., PlusSquare{});
+      const double three_index_constraint_cumulative = alg::accumulate(
+          three_index_constraint_all_components, 0., PlusSquare{});
+      const double constraint_energy_cumulative =
+          alg::accumulate(get(constraint_energy), 0., PlusSquare{});
+
+      const double gauge_H_t =
+          alg::accumulate(get<0>(gauge_H), 0., PlusSquare{});
+      const double gauge_H_x =
+          alg::accumulate(get<1>(gauge_H), 0., PlusSquare{});
+
+      components.emplace_back(
+          element_name + "Error" +
+              gr::Tags::SpacetimeMetric<Dim, Frame::Inertial>::name(),
+          error_in_psi_components);
+      components.emplace_back(
+          element_name + "Error" +
+              GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>::name(),
+          error_in_phi_components);
+      components.emplace_back(
+          element_name + "Error" +
+              GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>::name(),
+          error_in_pi_components);
+      components.emplace_back(element_name + "L2Norm" +
+                                  GeneralizedHarmonic::Tags::GaugeConstraint<
+                                      Dim, Frame::Inertial>::name(),
+                              gauge_constraint_all_components);
+      components.emplace_back(
+          element_name + "L2Norm" +
+              GeneralizedHarmonic::Tags::ThreeIndexConstraint<
+                  Dim, Frame::Inertial>::name(),
+          three_index_constraint_all_components);
+
+      for (size_t d = 0; d < Dim; ++d) {
+        const std::string component_suffix =
+            d == 0 ? "_x" : d == 1 ? "_y" : "_z";
+        components.emplace_back(
+            element_name + ::Tags::Coordinates<Dim, Frame::Inertial>::name() +
+                component_suffix,
+            inertial_coordinates.get(d));
+      }
+
+      // Send data to volume observer
+      auto& local_observer =
+          *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+               cache)
+               .ckLocalBranch();
+      Parallel::simple_action<observers::Actions::ContributeVolumeData>(
+          local_observer,
+          observers::ObservationId(
+              time.value(), typename Metavariables::element_observation_type{}),
+          std::string{"/element_data"},
+          observers::ArrayComponentId(
+              std::add_pointer_t<ParallelComponent>{nullptr},
+              Parallel::ArrayIndex<ElementIndex<Dim>>(array_index)),
+          std::move(components), extents);
+
+      // Send data to reduction observer
+      Parallel::simple_action<observers::Actions::ContributeReductionData>(
+          local_observer,
+          observers::ObservationId(
+              time.value(), typename Metavariables::element_observation_type{}),
+          std::string{"/element_data"},
+          std::vector<std::string>{
+              "Time", "NumberOfPoints", "PsiError", "PhiError", "PiError",
+              "L2NormGaugeConstraint", "L2NormThreeIndexConstraint",
+              "L2NormConstraintEnergy", "L2NormHt", "L2NormHx"},
+          reduction_data{
+              time.value(),
+              db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points(),
+              psi_error, phi_error, pi_error, gauge_constraint_cumulative,
+              three_index_constraint_cumulative, constraint_energy_cumulative,
+              gauge_H_t, gauge_H_x});
+    }
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -3,17 +3,27 @@
 
 #pragma once
 
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
+class DataVector;
+
 namespace brigand {
 template <class...>
 struct list;
 }  // namespace brigand
 
+namespace Tags {
 template <class>
 class Variables;
+}  // namespace Tags
 /// \endcond
 
 /*!
@@ -28,10 +38,27 @@ struct System {
   static constexpr size_t volume_dim = Dim;
   static constexpr bool is_euclidean = false;
 
-  using variables_tags = brigand::list<gr::Tags::SpacetimeMetric<Dim>,
-                                       Tags::Pi<Dim>, Tags::Phi<Dim>>;
-  using gradient_tags = variables_tags;
+  using variables_tag = ::Tags::Variables<tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::Pi<Dim, Frame::Inertial>, Tags::Phi<Dim, Frame::Inertial>>>;
+  using gradients_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+                 Tags::Pi<Dim, Frame::Inertial>,
+                 Tags::Phi<Dim, Frame::Inertial>>;
+  // `extras_tag` can be used with `Tags::DerivCompute` to get spatial
+  // derivatives of quantities that are otherwise not available within
+  // a `Variables<>` container.
+  using extras_tag = ::Tags::Variables<
+      tmpl::list<GeneralizedHarmonic::Tags::GaugeH<Dim, Frame::Inertial>>>;
 
-  using Variables = ::Variables<variables_tags>;
+  using compute_time_derivative = ComputeDuDt<Dim>;
+  using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
+  using char_speeds_tag = CharacteristicSpeedsCompute<Dim, Frame::Inertial>;
+  using compute_largest_characteristic_speed =
+      ComputeLargestCharacteristicSpeed<Dim, Frame::Inertial>;
+
+  template <typename Tag>
+  using magnitude_tag = ::Tags::NonEuclideanMagnitude<
+      Tag, gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
 };
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -45,6 +45,14 @@ struct System {
       tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
                  Tags::Pi<Dim, Frame::Inertial>,
                  Tags::Phi<Dim, Frame::Inertial>>;
+
+  // `constraints_tag` can be used with
+  // `dg::Events::ObserveFields` to observe constraint violations in volume
+  using constraints_tag = ::Tags::Variables<
+      tmpl::list<Tags::GaugeConstraint<Dim, Frame::Inertial>,
+                 Tags::ThreeIndexConstraint<Dim, Frame::Inertial>,
+                 Tags::ConstraintEnergy<Dim, Frame::Inertial>>>;
+
   // `extras_tag` can be used with `Tags::DerivCompute` to get spatial
   // derivatives of quantities that are otherwise not available within
   // a `Variables<>` container.

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -115,5 +115,52 @@ struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
     return "EvolvedFieldsFromCharacteristicFields";
   }
 };
+
+// @{
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief Tags corresponding to various constraints of the generalized
+ * harmonic system, and their diagnostically useful combinations.
+ * \details For details on how these are defined and computed, see
+ * `GaugeConstraintCompute`, `FConstraintCompute`, `TwoIndexConstraintCompute`,
+ * `ThreeIndexConstraintCompute`, `FourIndexConstraintCompute`, and
+ * `ConstraintEnergyCompute` respectively
+ */
+template <size_t SpatialDim, typename Frame>
+struct GaugeConstraint : db::SimpleTag {
+  using type = tnsr::a<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "GaugeConstraint"; }
+};
+
+template <size_t SpatialDim, typename Frame>
+struct FConstraint : db::SimpleTag {
+  using type = tnsr::a<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "FConstraint"; }
+};
+
+template <size_t SpatialDim, typename Frame>
+struct TwoIndexConstraint : db::SimpleTag {
+  using type = tnsr::ia<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "TwoIndexConstraint"; }
+};
+
+template <size_t SpatialDim, typename Frame>
+struct ThreeIndexConstraint : db::SimpleTag {
+  using type = tnsr::iaa<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "ThreeIndexConstraint"; }
+};
+
+template <size_t SpatialDim, typename Frame>
+struct FourIndexConstraint : db::SimpleTag {
+  using type = tnsr::iaa<DataVector, SpatialDim, Frame>;
+  static std::string name() noexcept { return "FourIndexConstraint"; }
+};
+
+template <size_t SpatialDim, typename Frame>
+struct ConstraintEnergy : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "ConstraintEnergy"; }
+};
+// @}
 }  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
     KerrSchild.cpp
     Minkowski.cpp
     Tov.cpp
+    WrapGh.cpp
     )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrapGh.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrapGh.cpp
@@ -1,0 +1,437 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrapGh.hpp"
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"        // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"     // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_forward_declare ::Tags::deriv
+
+/// \cond
+namespace GeneralizedHarmonic {
+namespace Solutions {
+template <typename SolutionType>
+tuples::TaggedTuple<gr::Tags::Lapse<DataVector>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/, tmpl::list<gr::Tags::Lapse<DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<gr::Tags::Lapse<DataVector>>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<typename WrapGh<SolutionType>::TimeDerivLapse>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<typename WrapGh<SolutionType>::TimeDerivLapse> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {
+      get<typename WrapGh<SolutionType>::TimeDerivLapse>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<typename WrapGh<SolutionType>::DerivLapse>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<typename WrapGh<SolutionType>::DerivLapse> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<typename WrapGh<SolutionType>::DerivLapse>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<gr::Tags::Shift<
+    GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+    Frame::Inertial, DataVector>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<gr::Tags::Shift<
+        GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+        Frame::Inertial, DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<gr::Tags::Shift<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<typename WrapGh<SolutionType>::TimeDerivShift>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<typename WrapGh<SolutionType>::TimeDerivShift> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {
+      get<typename WrapGh<SolutionType>::TimeDerivShift>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<typename WrapGh<SolutionType>::DerivShift>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<typename WrapGh<SolutionType>::DerivShift> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<DerivShift>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<gr::Tags::SpatialMetric<
+    GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+    Frame::Inertial, DataVector>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<gr::Tags::SpatialMetric<
+        GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+        Frame::Inertial, DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<gr::Tags::SpatialMetric<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<typename WrapGh<SolutionType>::TimeDerivSpatialMetric>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<typename WrapGh<SolutionType>::TimeDerivSpatialMetric> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<typename WrapGh<SolutionType>::TimeDerivSpatialMetric>(
+      intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<typename WrapGh<SolutionType>::DerivSpatialMetric>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<typename WrapGh<SolutionType>::DerivSpatialMetric> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<typename WrapGh<SolutionType>::DerivSpatialMetric>(
+      intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<gr::Tags::InverseSpatialMetric<
+    GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+    Frame::Inertial, DataVector>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<gr::Tags::InverseSpatialMetric<
+        GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+        Frame::Inertial, DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<gr::Tags::InverseSpatialMetric<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<gr::Tags::ExtrinsicCurvature<
+    GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+    Frame::Inertial, DataVector>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<gr::Tags::ExtrinsicCurvature<
+        GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+        Frame::Inertial, DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<gr::Tags::ExtrinsicCurvature<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DataVector>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  return {get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(intermediate_vars)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<gr::Tags::SpacetimeMetric<
+    GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+    Frame::Inertial, DataVector>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<gr::Tags::SpacetimeMetric<
+        GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+        Frame::Inertial, DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(intermediate_vars);
+  const auto& shift = get<gr::Tags::Shift<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars);
+
+  return {gr::spacetime_metric(lapse, shift, spatial_metric)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<GeneralizedHarmonic::Tags::Phi<
+    GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+    Frame::Inertial>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<GeneralizedHarmonic::Tags::Phi<
+        GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+        Frame::Inertial>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(intermediate_vars);
+  const auto& deriv_lapse =
+      get<typename WrapGh<SolutionType>::DerivLapse>(intermediate_vars);
+
+  const auto& shift = get<gr::Tags::Shift<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars);
+  const auto& deriv_shift =
+      get<typename WrapGh<SolutionType>::DerivShift>(intermediate_vars);
+
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars);
+  const auto& deriv_spatial_metric =
+      get<typename WrapGh<SolutionType>::DerivSpatialMetric>(intermediate_vars);
+
+  return {GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
+                                   spatial_metric, deriv_spatial_metric)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<GeneralizedHarmonic::Tags::Pi<
+    GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+    Frame::Inertial>>
+WrapGh<SolutionType>::variables(
+    const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<
+                                  SolutionType>::volume_dim>& /*x*/,
+    double /*t*/,
+    tmpl::list<GeneralizedHarmonic::Tags::Pi<
+        GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+        Frame::Inertial>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const noexcept {
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(intermediate_vars);
+  const auto& dt_lapse =
+      get<typename WrapGh<SolutionType>::TimeDerivLapse>(intermediate_vars);
+  const auto& deriv_lapse =
+      get<typename WrapGh<SolutionType>::DerivLapse>(intermediate_vars);
+
+  const auto& shift = get<gr::Tags::Shift<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars);
+  const auto& dt_shift =
+      get<typename WrapGh<SolutionType>::TimeDerivShift>(intermediate_vars);
+  const auto& deriv_shift =
+      get<typename WrapGh<SolutionType>::DerivShift>(intermediate_vars);
+
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<
+      GeneralizedHarmonic::Solutions::WrapGh<SolutionType>::volume_dim,
+      Frame::Inertial, DataVector>>(intermediate_vars);
+  const auto& dt_spatial_metric =
+      get<typename WrapGh<SolutionType>::TimeDerivSpatialMetric>(
+          intermediate_vars);
+  const auto& deriv_spatial_metric =
+      get<typename WrapGh<SolutionType>::DerivSpatialMetric>(intermediate_vars);
+
+  const auto& phi =
+      GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
+                               spatial_metric, deriv_spatial_metric);
+
+  return {GeneralizedHarmonic::pi(lapse, dt_lapse, shift, dt_shift,
+                                  spatial_metric, dt_spatial_metric, phi)};
+}
+}  // namespace Solutions
+}  // namespace GeneralizedHarmonic
+
+#define STYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template tuples::TaggedTuple<gr::Tags::Lapse<DataVector>>                   \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/, tmpl::list<gr::Tags::Lapse<DataVector>> /*meta*/,         \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<typename GeneralizedHarmonic::Solutions::      \
+                                   WrapGh<STYPE(data)>::TimeDerivLapse>       \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<typename GeneralizedHarmonic::Solutions::WrapGh<STYPE(       \
+          data)>::TimeDerivLapse> /*meta*/,                                   \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<typename GeneralizedHarmonic::Solutions::      \
+                                   WrapGh<STYPE(data)>::DerivLapse>           \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<typename GeneralizedHarmonic::Solutions::WrapGh<STYPE(       \
+          data)>::DerivLapse> /*meta*/,                                       \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<gr::Tags::Shift<                               \
+      GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,        \
+      Frame::Inertial, DataVector>>                                           \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<gr::Tags::Shift<                                             \
+          GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,    \
+          Frame::Inertial, DataVector>> /*meta*/,                             \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<typename GeneralizedHarmonic::Solutions::      \
+                                   WrapGh<STYPE(data)>::TimeDerivShift>       \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<typename GeneralizedHarmonic::Solutions::WrapGh<STYPE(       \
+          data)>::TimeDerivShift> /*meta*/,                                   \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<typename GeneralizedHarmonic::Solutions::      \
+                                   WrapGh<STYPE(data)>::DerivShift>           \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<typename GeneralizedHarmonic::Solutions::WrapGh<STYPE(       \
+          data)>::DerivShift> /*meta*/,                                       \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<gr::Tags::SpatialMetric<                       \
+      GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,        \
+      Frame::Inertial, DataVector>>                                           \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<gr::Tags::SpatialMetric<                                     \
+          GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,    \
+          Frame::Inertial, DataVector>> /*meta*/,                             \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<                                               \
+      typename GeneralizedHarmonic::Solutions::WrapGh<STYPE(                  \
+          data)>::TimeDerivSpatialMetric>                                     \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<typename GeneralizedHarmonic::Solutions::WrapGh<STYPE(       \
+          data)>::TimeDerivSpatialMetric> /*meta*/,                           \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<typename GeneralizedHarmonic::Solutions::      \
+                                   WrapGh<STYPE(data)>::DerivSpatialMetric>   \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<typename GeneralizedHarmonic::Solutions::WrapGh<STYPE(       \
+          data)>::DerivSpatialMetric> /*meta*/,                               \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<gr::Tags::InverseSpatialMetric<                \
+      GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,        \
+      Frame::Inertial, DataVector>>                                           \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<gr::Tags::InverseSpatialMetric<                              \
+          GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,    \
+          Frame::Inertial, DataVector>> /*meta*/,                             \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<gr::Tags::ExtrinsicCurvature<                  \
+      GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,        \
+      Frame::Inertial, DataVector>>                                           \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<gr::Tags::ExtrinsicCurvature<                                \
+          GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,    \
+          Frame::Inertial, DataVector>> /*meta*/,                             \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DataVector>>    \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataVector>> /*meta*/,        \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<gr::Tags::SpacetimeMetric<                     \
+      GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,        \
+      Frame::Inertial, DataVector>>                                           \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<gr::Tags::SpacetimeMetric<                                   \
+          GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,    \
+          Frame::Inertial, DataVector>> /*meta*/,                             \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<GeneralizedHarmonic::Tags::Pi<                 \
+      GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,        \
+      Frame::Inertial>>                                                       \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<GeneralizedHarmonic::Tags::Pi<                               \
+          GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,    \
+          Frame::Inertial>> /*meta*/,                                         \
+      const IntermediateVars& intermediate_vars) const noexcept;              \
+  template tuples::TaggedTuple<GeneralizedHarmonic::Tags::Phi<                \
+      GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,        \
+      Frame::Inertial>>                                                       \
+  GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::variables(             \
+      const tnsr::I<DataVector, GeneralizedHarmonic::Solutions::WrapGh<STYPE( \
+                                    data)>::volume_dim>& /*x*/,               \
+      double /*t*/,                                                           \
+      tmpl::list<GeneralizedHarmonic::Tags::Phi<                              \
+          GeneralizedHarmonic::Solutions::WrapGh<STYPE(data)>::volume_dim,    \
+          Frame::Inertial>> /*meta*/,                                         \
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (gr::Solutions::Minkowski<1>,
+                                      gr::Solutions::Minkowski<2>,
+                                      gr::Solutions::Minkowski<3>,
+                                      gr::Solutions::KerrSchild))
+
+#undef DIM
+#undef STYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrapGh.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrapGh.hpp
@@ -1,0 +1,206 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // for tags
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma: no_forward_declare Tags::deriv
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Tags {
+template <typename Tag>
+struct dt;
+}  // namespace Tags
+/// \endcond
+
+namespace GeneralizedHarmonic {
+namespace Solutions {
+
+/*!
+ * \brief A wrapper for general-relativity analytic solutions that loads
+ * the analytic solution and then adds a function that returns
+ * any combination of the generalized-harmonic evolution variables,
+ * specifically `gr::Tags::SpacetimeMetric`, `GeneralizedHarmonic::Tags::Pi`,
+ * and `GeneralizedHarmonic::Tags::Phi`
+ */
+template <typename SolutionType>
+class WrapGh : public SolutionType {
+ public:
+  using SolutionType::SolutionType;
+
+  static constexpr size_t volume_dim = SolutionType::volume_dim;
+  using options = typename SolutionType::options;
+  static constexpr OptionString help = SolutionType::help;
+
+  using DerivLapse = ::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                                   tmpl::size_t<volume_dim>, Frame::Inertial>;
+  using DerivShift =
+      ::Tags::deriv<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
+                    tmpl::size_t<volume_dim>, Frame::Inertial>;
+  using DerivSpatialMetric = ::Tags::deriv<
+      gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>,
+      tmpl::size_t<volume_dim>, Frame::Inertial>;
+  using TimeDerivLapse = ::Tags::dt<gr::Tags::Lapse<DataVector>>;
+  using TimeDerivShift =
+      ::Tags::dt<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>;
+  using TimeDerivSpatialMetric = ::Tags::dt<
+      gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>>;
+
+  using IntermediateVars = tuples::tagged_tuple_from_typelist<
+      typename SolutionType::template tags<DataVector>>;
+
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataVector, volume_dim>& x, double t,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    // Get the underlying solution's variables using the solution's tags list,
+    // store in IntermediateVariables
+    const IntermediateVars& intermediate_vars = SolutionType::variables(
+        x, t, typename SolutionType::template tags<DataVector>{});
+
+    return {
+        get<Tags>(variables(x, t, tmpl::list<Tags>{}, intermediate_vars))...};
+  }
+
+  //  template <typename... Tags>
+  //  tuples::TaggedTuple<Tags...> variables(
+  //      const tnsr::I<DataVector, volume_dim>& x, double t,
+  //      tmpl::list<Tags...> /*meta*/,
+  //      const IntermediateVars& intermediate_vars) const noexcept {
+  //    static_assert(sizeof...(Tags) > 1,
+  //                  "The generic template will recurse infinitely if only one
+  //                  " "tag is being retrieved.");
+  //    return {
+  //        get<Tags>(variables(x, t, tmpl::list<Tags>{},
+  //        intermediate_vars))...};
+  //  }
+
+  template <typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataVector, volume_dim>& x,
+                                     double t, tmpl::list<Tag> /*meta*/) const
+      noexcept {
+    const IntermediateVars& intermediate_vars = SolutionType::variables(
+        x, t, typename SolutionType::template tags<DataVector>{});
+    return {get<Tag>(variables(x, t, tmpl::list<Tag>{}, intermediate_vars))};
+  }
+
+ private:
+  tuples::TaggedTuple<gr::Tags::Lapse<DataVector>> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<gr::Tags::Lapse<DataVector>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<TimeDerivLapse> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<TimeDerivLapse> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<DerivLapse> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<DerivLapse> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>
+  variables(const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+            tmpl::list<gr::Tags::Shift<volume_dim, Frame::Inertial,
+                                       DataVector>> /*meta*/,
+            const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<TimeDerivShift> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<TimeDerivShift> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<DerivShift> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<DerivShift> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<
+      gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>>
+  variables(const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+            tmpl::list<gr::Tags::SpatialMetric<volume_dim, Frame::Inertial,
+                                               DataVector>> /*meta*/,
+            const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<TimeDerivSpatialMetric> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<TimeDerivSpatialMetric> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<DerivSpatialMetric> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<DerivSpatialMetric> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<
+      gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataVector>>
+  variables(const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+            tmpl::list<gr::Tags::InverseSpatialMetric<
+                volume_dim, Frame::Inertial, DataVector>> /*meta*/,
+            const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<
+      gr::Tags::ExtrinsicCurvature<volume_dim, Frame::Inertial, DataVector>>
+  variables(const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+            tmpl::list<gr::Tags::ExtrinsicCurvature<volume_dim, Frame::Inertial,
+                                                    DataVector>> /*meta*/,
+            const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DataVector>> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataVector>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<
+      gr::Tags::SpacetimeMetric<volume_dim, Frame::Inertial, DataVector>>
+  variables(const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+            tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, Frame::Inertial,
+                                                 DataVector>> /*meta*/,
+            const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<
+      GeneralizedHarmonic::Tags::Pi<volume_dim, Frame::Inertial>>
+  variables(const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+            tmpl::list<GeneralizedHarmonic::Tags::Pi<volume_dim,
+                                                     Frame::Inertial>> /*meta*/,
+            const IntermediateVars& intermediate_vars) const noexcept;
+
+  tuples::TaggedTuple<
+      GeneralizedHarmonic::Tags::Phi<volume_dim, Frame::Inertial>>
+  variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<
+          GeneralizedHarmonic::Tags::Phi<volume_dim, Frame::Inertial>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const noexcept;
+
+ public:
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};                                      // namespace Solutions
+
+template <typename SolutionType>
+inline constexpr bool operator==(const WrapGh<SolutionType>& /*lhs*/,
+                                 const WrapGh<SolutionType>& /*rhs*/) noexcept {
+  return true;
+}
+
+template <typename SolutionType>
+inline constexpr bool operator!=(const WrapGh<SolutionType>& /*lhs*/,
+                                 const WrapGh<SolutionType>& /*rhs*/) noexcept {
+  return false;
+}
+}  // namespace Solutions
+}  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -6,20 +6,36 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare Tags::deriv
 
 /// \cond
 namespace gsl {
 template <class T>
 class not_null;
 }  // namespace gsl
+namespace Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace Tags
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
@@ -790,6 +806,305 @@ struct DerivSpacetimeMetricCompute
     return deriv_spacetime_metric;
   }
   using base = gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame, DataVector>;
+  using type = typename base::type;
+};
+
+// @{
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief Compute item to compute constraint-damping parameters for a single-BH
+ * evolution.
+ *
+ * \details Can be retrieved using
+ * `GeneralizedHarmonic::Tags::ConstraintGamma0`,
+ * `GeneralizedHarmonic::Tags::ConstraintGamma0`, and
+ * `GeneralizedHarmonic::Tags::ConstraintGamma0`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct ConstraintGamma0Compute : ConstraintGamma0, db::ComputeTag {
+  using argument_tags = tmpl::list<::Tags::Coordinates<SpatialDim, Frame>>;
+  static auto function(
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
+    const DataVector r_squared = get(dot_product(coords, coords));
+    Scalar<DataVector> gamma = make_with_value<type>(coords, 0.);
+    get(gamma) = 3. * exp(-0.5 * r_squared / 64.) + 0.001;
+    return gamma;
+  }
+  using base = ConstraintGamma0;
+  using type = typename base::type;
+};
+
+template <size_t SpatialDim, typename Frame>
+struct ConstraintGamma1Compute : ConstraintGamma1, db::ComputeTag {
+  using argument_tags = tmpl::list<::Tags::Coordinates<SpatialDim, Frame>>;
+  static constexpr auto function(
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
+    return make_with_value<type>(coords, -1.);
+  }
+  using base = ConstraintGamma1;
+  using type = typename base::type;
+};
+
+template <size_t SpatialDim, typename Frame>
+struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
+  using argument_tags = tmpl::list<::Tags::Coordinates<SpatialDim, Frame>>;
+  static auto function(
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
+    const DataVector r_squared = get(dot_product(coords, coords));
+    Scalar<DataVector> gamma = make_with_value<type>(coords, 0.);
+    get(gamma) = exp(-0.5 * r_squared / 64.) + 0.001;
+    return gamma;
+  }
+  using base = ConstraintGamma2;
+  using type = typename base::type;
+};
+// @}
+
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief  Compute item to get the implicit gauge source function from 3 + 1
+ * quantities.
+ *
+ * \details See `gauge_source()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::GaugeH`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct GaugeHImplicitFrom3p1QuantitiesCompute : GaugeH<SpatialDim, Frame>,
+                                                db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+                 ::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                               tmpl::size_t<SpatialDim>, Frame>,
+                 gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                 ::Tags::dt<gr::Tags::Shift<SpatialDim, Frame, DataVector>>,
+                 ::Tags::deriv<gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                               tmpl::size_t<SpatialDim>, Frame>,
+                 gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
+                 gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                 gr::Tags::TraceSpatialChristoffelFirstKind<SpatialDim, Frame,
+                                                            DataVector>>;
+  static constexpr auto function = &gauge_source<SpatialDim, Frame, DataVector>;
+  using base = GaugeH<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief  Compute item to get spacetime derivative of the gauge source function
+ * from its spatial and time derivatives.
+ *
+ * \details Can be retrieved using
+ * `GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct SpacetimeDerivGaugeHCompute : SpacetimeDerivGaugeH<SpatialDim, Frame>,
+                                     db::ComputeTag {
+  using argument_tags = tmpl::list<
+      ::Tags::dt<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame>>,
+      ::Tags::deriv<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame>,
+                    tmpl::size_t<SpatialDim>, Frame>>;
+  static constexpr tnsr::ab<DataVector, SpatialDim, Frame> function(
+      const tnsr::a<DataVector, SpatialDim, Frame>& time_deriv_gauge_source,
+      const tnsr::ia<DataVector, SpatialDim, Frame>& deriv_gauge_source) {
+    auto spacetime_deriv_gauge_source =
+        make_with_value<tnsr::ab<DataVector, SpatialDim, Frame>>(
+            time_deriv_gauge_source, 0.0);
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      spacetime_deriv_gauge_source.get(0, b) = time_deriv_gauge_source.get(b);
+      for (size_t a = 1; a < SpatialDim + 1; ++a) {
+        spacetime_deriv_gauge_source.get(a, b) =
+            deriv_gauge_source.get(a - 1, b);
+      }
+    }
+    return spacetime_deriv_gauge_source;
+  }
+  using base = SpacetimeDerivGaugeH<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief Compute item to get the gauge constraint for the
+ * generalized harmonic evolution system.
+ *
+ * \details See `gauge_constraint()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::GaugeConstraint`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct GaugeConstraintCompute : GaugeConstraint<SpatialDim, Frame>,
+                                db::ComputeTag {
+  using argument_tags = tmpl::list<
+      GaugeH<SpatialDim, Frame>,
+      gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
+      gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+      gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
+      gr::Tags::InverseSpacetimeMetric<SpatialDim, Frame, DataVector>,
+      Pi<SpatialDim, Frame>, Phi<SpatialDim, Frame>>;
+  static constexpr tnsr::a<DataVector, SpatialDim, Frame> (*function)(
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&,
+      const tnsr::AA<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
+      &gauge_constraint<SpatialDim, Frame, DataVector>;
+  using base = GaugeConstraint<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief Compute item to get the F-constraint for the
+ * generalized harmonic evolution system.
+ *
+ * \details See `f_constraint()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::FConstraint`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct FConstraintCompute : FConstraint<SpatialDim, Frame>, db::ComputeTag {
+  using argument_tags = tmpl::list<
+      GaugeH<SpatialDim, Frame>,
+      ::Tags::deriv<GaugeH<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
+      gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+      gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
+      gr::Tags::InverseSpacetimeMetric<SpatialDim, Frame, DataVector>,
+      Pi<SpatialDim, Frame>, Phi<SpatialDim, Frame>,
+      ::Tags::deriv<Pi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      ::Tags::deriv<Phi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      ConstraintGamma2, ThreeIndexConstraint<SpatialDim, Frame>>;
+  static constexpr tnsr::a<DataVector, SpatialDim, Frame> (*function)(
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::ia<DataVector, SpatialDim, Frame>&,
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&,
+      const tnsr::AA<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::ijaa<DataVector, SpatialDim, Frame>&,
+      const Scalar<DataVector>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
+      &f_constraint<SpatialDim, Frame, DataVector>;
+  using base = FConstraint<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief Compute item to get the two-index constraint for the
+ * generalized harmonic evolution system.
+ *
+ * \details See `two_index_constraint()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::TwoIndexConstraint`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim, Frame>,
+                                   db::ComputeTag {
+  using argument_tags = tmpl::list<
+      ::Tags::deriv<GaugeH<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
+      gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+      gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
+      gr::Tags::InverseSpacetimeMetric<SpatialDim, Frame, DataVector>,
+      Pi<SpatialDim, Frame>, Phi<SpatialDim, Frame>,
+      ::Tags::deriv<Pi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      ::Tags::deriv<Phi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      ConstraintGamma2, ThreeIndexConstraint<SpatialDim, Frame>>;
+  static constexpr tnsr::ia<DataVector, SpatialDim, Frame> (*function)(
+      const tnsr::ia<DataVector, SpatialDim, Frame>&,
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&,
+      const tnsr::AA<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::ijaa<DataVector, SpatialDim, Frame>&,
+      const Scalar<DataVector>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
+      &two_index_constraint<SpatialDim, Frame, DataVector>;
+  using base = TwoIndexConstraint<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \brief Compute item to get the three-index constraint for the
+ * generalized harmonic evolution system.
+ *
+ * \details See `three_index_constraint()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::ThreeIndexConstraint`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct ThreeIndexConstraintCompute : ThreeIndexConstraint<SpatialDim, Frame>,
+                                     db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame, DataVector>,
+                 Phi<SpatialDim, Frame>>;
+  static constexpr tnsr::iaa<DataVector, SpatialDim, Frame> (*function)(
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
+      &three_index_constraint<SpatialDim, Frame, DataVector>;
+  using base = ThreeIndexConstraint<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief Compute item to get the four-index constraint for the
+ * generalized harmonic evolution system.
+ *
+ * \details See `four_index_constraint()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::FourIndexConstraint`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct FourIndexConstraintCompute : FourIndexConstraint<SpatialDim, Frame>,
+                                    db::ComputeTag {
+  using argument_tags = tmpl::list<
+      ::Tags::deriv<Phi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>>;
+  static constexpr tnsr::iaa<DataVector, SpatialDim, Frame> (*function)(
+      const tnsr::ijaa<DataVector, SpatialDim, Frame>&) =
+      &four_index_constraint<SpatialDim, Frame, DataVector>;
+  using base = FourIndexConstraint<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralizedHarmonicGroup
+ * \brief Compute item to get combined energy in all constraints for the
+ * generalized harmonic evolution system.
+ *
+ * \details See `constraint_energy()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::ConstraintEnergy`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct ConstraintEnergyCompute : ConstraintEnergy<SpatialDim, Frame>,
+                                 db::ComputeTag {
+  using argument_tags =
+      tmpl::list<GaugeConstraint<SpatialDim, Frame>,
+                 FConstraint<SpatialDim, Frame>,
+                 TwoIndexConstraint<SpatialDim, Frame>,
+                 ThreeIndexConstraint<SpatialDim, Frame>,
+                 FourIndexConstraint<SpatialDim, Frame>,
+                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
+                 gr::Tags::DetSpatialMetric<DataVector>>;
+  static constexpr auto function(
+      const tnsr::a<DataVector, SpatialDim, Frame>& gauge_constraint,
+      const tnsr::a<DataVector, SpatialDim, Frame>& f_constraint,
+      const tnsr::ia<DataVector, SpatialDim, Frame>& two_index_constraint,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>& three_index_constraint,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>& four_index_constraint,
+      const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+      const Scalar<DataVector>& spatial_metric_determinant) noexcept {
+    return constraint_energy<SpatialDim, Frame, DataVector>(
+        gauge_constraint, f_constraint, two_index_constraint,
+        three_index_constraint, four_index_constraint, inverse_spatial_metric,
+        spatial_metric_determinant);
+  }
+  using base = ConstraintEnergy<SpatialDim, Frame>;
   using type = typename base::type;
 };
 }  // namespace Tags

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -9,6 +9,11 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 /// \cond
 namespace gsl {
@@ -456,4 +461,336 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
 // @}
+
+namespace Tags {
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for the auxiliary variable \f$\Phi_{iab}\f$ used by the
+ * generalized harmonic formulation of Einstein's equations.
+ *
+ * \details See `phi()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::Phi`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct PhiCompute : Phi<SpatialDim, Frame>, db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::Lapse<DataVector>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<SpatialDim>,
+                    Frame>,
+      gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+      ::Tags::deriv<gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
+      ::Tags::deriv<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
+                    tmpl::size_t<SpatialDim>, Frame>>;
+  static constexpr tnsr::iaa<DataVector, SpatialDim, Frame> (*function)(
+      const Scalar<DataVector>&, const tnsr::i<DataVector, SpatialDim, Frame>&,
+      const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::iJ<DataVector, SpatialDim, Frame>&,
+      const tnsr::ii<DataVector, SpatialDim, Frame>&,
+      const tnsr::ijj<DataVector, SpatialDim, Frame>&) =
+      &phi<SpatialDim, Frame, DataVector>;
+  using base = Phi<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item the conjugate momentum \f$\Pi_{ab}\f$ of the spacetime
+ * metric \f$ \psi_{ab} \f$.
+ *
+ * \details See `pi()`. Can be retrieved using `GeneralizedHarmonic::Tags::Pi`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct PiCompute : Pi<SpatialDim, Frame>, db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::Lapse<DataVector>, ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+      gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+      ::Tags::dt<gr::Tags::Shift<SpatialDim, Frame, DataVector>>,
+      gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
+      ::Tags::dt<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>>,
+      Phi<SpatialDim, Frame>>;
+  static constexpr tnsr::aa<DataVector, SpatialDim, Frame> (*function)(
+      const Scalar<DataVector>&, const Scalar<DataVector>&,
+      const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::ii<DataVector, SpatialDim, Frame>&,
+      const tnsr::ii<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
+      &pi<SpatialDim, Frame, DataVector>;
+  using base = Pi<SpatialDim, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get extrinsic curvature from generalized harmonic
+ * variables and the spacetime normal vector.
+ *
+ * \details See `extrinsic_curvature()`. Can be retrieved using
+ * `gr::Tags::ExtrinsicCurvature`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct ExtrinsicCurvatureCompute
+    : gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataVector>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+                 Pi<SpatialDim, Frame>, Phi<SpatialDim, Frame>>;
+  static constexpr auto function =
+      &extrinsic_curvature<SpatialDim, Frame, DataVector>;
+  using base = gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataVector>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get the trace of extrinsic curvature from generalized
+ * harmonic variables and the spacetime normal vector.
+ *
+ * \details See `extrinsic_curvature()` for how the extrinsic curvature
+ * \f$ K_{ij}\f$. Its trace is taken as
+ * \f{align}
+ *     tr(K) &= g^{ij} K_{ij}.
+ * \f}
+ *
+ * Can be retrieved using `gr::Tags::TraceExtrinsicCurvature`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct TraceExtrinsicCurvatureCompute
+    : gr::Tags::TraceExtrinsicCurvature<DataVector>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataVector>,
+                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>>;
+  static constexpr Scalar<DataVector> (*function)(
+      const tnsr::ii<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&) = &trace;
+  using base = gr::Tags::TraceExtrinsicCurvature<DataVector>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get spatial derivatives of the spatial metric from
+ *        the generalized harmonic spatial derivative variable.
+ *
+ * \details See `deriv_spatial_metric()`. Can be retrieved using
+ * `gr::Tags::SpatialMetric` wrapped in `Tags::deriv`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct DerivSpatialMetricCompute
+    : ::Tags::deriv<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<Phi<SpatialDim, Frame>>;
+  static constexpr tnsr::ijj<DataVector, SpatialDim, Frame> (*function)(
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
+      &deriv_spatial_metric<SpatialDim, Frame>;
+  using base =
+      ::Tags::deriv<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
+                    tmpl::size_t<SpatialDim>, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get spatial derivatives of lapse (N) from the
+ * generalized harmonic variables and spacetime unit normal 1-form.
+ *
+ * \details See `spatial_deriv_of_lapse()`. Can be retrieved using
+ * `gr::Tags::Lapse` wrapped in `Tags::deriv`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct DerivLapseCompute : ::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                                         tmpl::size_t<SpatialDim>, Frame>,
+                           db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+                 Phi<SpatialDim, Frame>>;
+  static constexpr tnsr::i<DataVector, SpatialDim, Frame> (*function)(
+      const Scalar<DataVector>&, const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
+      &spatial_deriv_of_lapse<SpatialDim, Frame>;
+  using base = ::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                             tmpl::size_t<SpatialDim>, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get spatial derivatives of the shift vector from
+ *        generalized harmonic and geometric variables
+ *
+ * \details See `spatial_deriv_of_shift()`. Can be retrieved using
+ * `gr::Tags::Shift` wrapped in `Tags::deriv`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct DerivShiftCompute
+    : ::Tags::deriv<gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::InverseSpacetimeMetric<SpatialDim, Frame, DataVector>,
+      gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+      Phi<SpatialDim, Frame>>;
+  static constexpr tnsr::iJ<DataVector, SpatialDim, Frame> (*function)(
+      const Scalar<DataVector>&, const tnsr::AA<DataVector, SpatialDim, Frame>&,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&) =
+      &spatial_deriv_of_shift<SpatialDim, Frame, DataVector>;
+  using base = ::Tags::deriv<gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                             tmpl::size_t<SpatialDim>, Frame>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get time derivative of the spatial metric from
+ *        generalized harmonic and geometric variables
+ *
+ * \details See `time_deriv_of_spatial_metric()`. Can be retrieved using
+ * `gr::Tags::SpatialMetric` wrapped in `Tags::dt`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct TimeDerivSpatialMetricCompute
+    : ::Tags::dt<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                 Phi<SpatialDim, Frame>, Pi<SpatialDim, Frame>>;
+  static constexpr tnsr::ii<DataVector, SpatialDim, Frame> (*function)(
+      const Scalar<DataVector>&, const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&) =
+      &time_deriv_of_spatial_metric<SpatialDim, Frame>;
+  using base =
+      ::Tags::dt<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get time derivative of lapse (N) from the generalized
+ *        harmonic variables, lapse, shift and the spacetime unit normal 1-form.
+ *
+ * \details See `time_deriv_of_lapse()`. Can be retrieved using
+ * `gr::Tags::Lapse` wrapped in `Tags::dt`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct TimeDerivLapseCompute : ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+                               db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                 gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+                 Phi<SpatialDim, Frame>, Pi<SpatialDim, Frame>>;
+  static constexpr Scalar<DataVector> (*function)(
+      const Scalar<DataVector>&, const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&) =
+      &time_deriv_of_lapse<SpatialDim, Frame>;
+  using base = ::Tags::dt<gr::Tags::Lapse<DataVector>>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get time derivative of the shift vector from
+ *        the generalized harmonic and geometric variables
+ *
+ * \details See `time_deriv_of_shift()`. Can be retrieved using
+ * `gr::Tags::Shift` wrapped in `Tags::dt`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct TimeDerivShiftCompute
+    : ::Tags::dt<gr::Tags::Shift<SpatialDim, Frame, DataVector>>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
+                 gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+                 Phi<SpatialDim, Frame>, Pi<SpatialDim, Frame>>;
+  static constexpr tnsr::I<DataVector, SpatialDim, Frame> (*function)(
+      const Scalar<DataVector>&, const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&) =
+      &time_deriv_of_shift<SpatialDim, Frame, DataVector>;
+  using base = ::Tags::dt<gr::Tags::Shift<SpatialDim, Frame, DataVector>>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get spacetime derivative of spacetime metric from
+ * spatial metric, lapse, shift, and their space and time derivatives.
+ *
+ * \details See `derivatives_of_spacetime_metric()`. Can be retrieved using
+ * `gr::Tags::DerivativesOfSpacetimeMetric`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct DerivativesOfSpacetimeMetricCompute
+    : gr::Tags::DerivativesOfSpacetimeMetric<SpatialDim, Frame, DataVector>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::Lapse<DataVector>, ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<SpatialDim>,
+                    Frame>,
+      gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+      ::Tags::dt<gr::Tags::Shift<SpatialDim, Frame, DataVector>>,
+      ::Tags::deriv<gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
+      ::Tags::dt<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>>,
+      ::Tags::deriv<gr::Tags::SpatialMetric<SpatialDim, Frame, DataVector>,
+                    tmpl::size_t<SpatialDim>, Frame>>;
+  static constexpr auto function =
+      &gr::derivatives_of_spacetime_metric<SpatialDim, Frame, DataVector>;
+  using base =
+      gr::Tags::DerivativesOfSpacetimeMetric<SpatialDim, Frame, DataVector>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get spatial derivative of spacetime metric from
+ * spatial metric, lapse, shift, and their space and time derivatives.
+ *
+ * \details Extracts spatial derivatives from spacetime derivatives computed
+ * with `derivatives_of_spacetime_metric()`. Can be retrieved using
+ * `gr::Tags::SpacetimeMetric` wrapped in `Tags::deriv`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct DerivSpacetimeMetricCompute
+    : gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame, DataVector>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::DerivativesOfSpacetimeMetric<SpatialDim, Frame, DataVector>>;
+  static constexpr auto function(
+      const tnsr::abb<DataVector, SpatialDim, Frame>&
+          spacetime_deriv_of_spacetime_metric) noexcept {
+    auto deriv_spacetime_metric =
+        make_with_value<tnsr::iaa<DataVector, SpatialDim, Frame>>(
+            spacetime_deriv_of_spacetime_metric, 0.);
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t a = 0; a < SpatialDim + 1; ++a) {
+        for (size_t b = a; b < SpatialDim + 1; ++b) {
+          deriv_spacetime_metric.get(i, a, b) =
+              spacetime_deriv_of_spacetime_metric.get(i + 1, a, b);
+        }
+      }
+    }
+    return deriv_spacetime_metric;
+  }
+  using base = gr::Tags::DerivSpacetimeMetric<SpatialDim, Frame, DataVector>;
+  using type = typename base::type;
+};
+}  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -6,9 +6,16 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstddef>
+#include <cstdint>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace gsl {
@@ -190,4 +197,219 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
 
+namespace Tags {
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spacetime metric \f$\psi_{ab}\f$ from the
+ * lapse \f$N\f$, shift \f$N^i\f$, and spatial metric \f$g_{ij}\f$..
+ *
+ * \details Can be retrieved using `gr::Tags::SpacetimeMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeMetricCompute : SpacetimeMetric<SpatialDim, Frame, DataType>,
+                                db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>,
+                 SpatialMetric<SpatialDim, Frame, DataType>>;
+  using base = SpacetimeMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+  static constexpr tnsr::aa<DataType, SpatialDim, Frame> (*function)(
+      const Scalar<DataType>&, const tnsr::I<DataType, SpatialDim, Frame>&,
+      const tnsr::ii<DataType, SpatialDim, Frame>&) =
+      &spacetime_metric<SpatialDim, Frame, DataType>;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for inverse spacetime metric \f$\psi^{ab}\f$
+ * in terms of the lapse \f$N\f$, shift \f$N^i\f$, and inverse
+ * spatial metric \f$g^{ij}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::InverseSpacetimeMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct InverseSpacetimeMetricCompute
+    : InverseSpacetimeMetric<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function =
+      &inverse_spacetime_metric<SpatialDim, Frame, DataType>;
+  using base = InverseSpacetimeMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spatial metric \f$g_{ij}\f$ from the
+ * spacetime metric \f$\psi_{ab}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::SpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpatialMetricCompute : SpatialMetric<SpatialDim, Frame, DataType>,
+                              db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpacetimeMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function = &spatial_metric<SpatialDim, Frame, DataType>;
+  using base = SpatialMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spatial metric determinant \f$\g\f$
+ * and inversre \f$g^{ij}\f$in terms of the spatial metric \f$g_{ij}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::DetAndInverseSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct DetAndInverseSpatialMetricCompute
+    : DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<SpatialMetric<SpatialDim, Frame, DataType>>;
+  using base = DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+  static constexpr auto function =
+      &determinant_and_inverse<DataType,
+                               tmpl::integral_list<std::int32_t, 1, 1>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get the square root of the determinant of the spatial
+ * metric \f$\sqrt{g}\f$ via `gr::Tags::DetAndInverseSpatialMetric`.
+ *
+ * \details Can be retrieved using `gr::Tags::DetSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct DetSpatialMetricCompute : DetSpatialMetric<DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static auto& function(
+      const std::pair<Scalar<DataType>, tnsr::II<DataType, SpatialDim, Frame>>&
+          det_and_inverse_spatial_metric) {
+    return det_and_inverse_spatial_metric.first;
+  }
+  using base = DetSpatialMetric<DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item to get the square root of the determinant of the spatial
+ * metric \f$\sqrt{g}\f$ via `gr::Tags::DetAndInverseSpatialMetric`.
+ *
+ * \details Can be retrieved using `gr::Tags::SqrtDetSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SqrtDetSpatialMetricCompute : SqrtDetSpatialMetric<DataType>,
+                                     db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static Scalar<DataType> function(
+      const std::pair<Scalar<DataType>, tnsr::II<DataType, SpatialDim, Frame>>&
+          det_and_inverse_spatial_metric) {
+    return Scalar<DataType>{sqrt(get(det_and_inverse_spatial_metric.first))};
+  }
+  using base = SqrtDetSpatialMetric<DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for inverse spatial metric \f$\g^{ij}\f$
+ * via `gr::Tags::DetAndInverseSpatialMetric`.
+ *
+ * \details Can be retrieved using `gr::Tags::InverseSpatialMetric`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct InverseSpatialMetricCompute
+    : InverseSpatialMetric<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DetAndInverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static const auto& function(
+      const std::pair<Scalar<DataType>, tnsr::II<DataType, SpatialDim, Frame>>&
+          det_and_inverse_spatial_metric) {
+    return det_and_inverse_spatial_metric.second;
+  }
+  using base = InverseSpatialMetric<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for shift \f$N^i\f$ from the spacetime metric
+ * \f$\psi_{ab}\f$ and the inverse spatial metric \f$g^{ij}\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::Shift`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct ShiftCompute : Shift<SpatialDim, Frame, DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpacetimeMetric<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function = &shift<SpatialDim, Frame, DataType>;
+  using base = Shift<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for lapse \f$N\f$ from the spacetime metric
+ * \f$\psi_{ab}\f$ and the shift \f$N^i\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::Lapse`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct LapseCompute : Lapse<DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Shift<SpatialDim, Frame, DataType>,
+                 SpacetimeMetric<SpatialDim, Frame, DataType>>;
+  static constexpr auto function = &lapse<SpatialDim, Frame, DataType>;
+  using base = Lapse<DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spacetime normal oneform \f$n_a\f$ from
+ * the lapse \f$N\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::SpacetimeNormalOneForm`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeNormalOneFormCompute
+    : SpacetimeNormalOneForm<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<Lapse<DataType>>;
+  static constexpr auto function =
+      &spacetime_normal_one_form<SpatialDim, Frame, DataType>;
+  using base = SpacetimeNormalOneForm<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute item for spacetime normal vector \f$n^a\f$ from
+ * the lapse \f$N\f$ and the shift \f$N^i\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::SpacetimeNormalVector`.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpacetimeNormalVectorCompute
+    : SpacetimeNormalVector<SpatialDim, Frame, DataType>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Lapse<DataType>, Shift<SpatialDim, Frame, DataType>>;
+  static constexpr auto function =
+      &spacetime_normal_vector<SpatialDim, Frame, DataType>;
+  using base = SpacetimeNormalVector<SpatialDim, Frame, DataType>;
+  using type = typename base::type;
+};
+}  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -13,7 +13,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -28,9 +28,19 @@ struct SpatialMetric : db::SimpleTag {
   static std::string name() noexcept { return "SpatialMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
+struct DetAndInverseSpatialMetric : db::SimpleTag {
+  using type = std::pair<Scalar<DataType>, tnsr::II<DataType, Dim, Frame>>;
+  static std::string name() noexcept { return "DetAndInverseSpatialMetric"; }
+};
+template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataType, Dim, Frame>;
   static std::string name() noexcept { return "InverseSpatialMetric"; }
+};
+template <typename DataType>
+struct DetSpatialMetric : db::SimpleTag {
+  using type = Scalar<DataType>;
+  static std::string name() noexcept { return "DetSpatialMetric"; }
 };
 template <typename DataType>
 struct SqrtDetSpatialMetric : db::SimpleTag {
@@ -47,7 +57,16 @@ struct Lapse : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "Lapse"; }
 };
-
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivSpacetimeMetric : db::SimpleTag {
+  using type = tnsr::iaa<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "DerivSpacetimeMetric"; }
+};
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivativesOfSpacetimeMetric : db::SimpleTag {
+  using type = tnsr::abb<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "DerivativesOfSpacetimeMetric"; }
+};
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
@@ -83,6 +102,13 @@ struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
   static std::string name() noexcept {
     return "TraceSpacetimeChristoffelFirstKind";
+  }
+};
+template <size_t Dim, typename Frame, typename DataType>
+struct TraceSpatialChristoffelFirstKind : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+  static std::string name() noexcept {
+    return "TraceSpatialChristoffelFirstKind";
   }
 };
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -6,7 +6,9 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "TagsDeclarations.hpp"
 
 namespace gr {
@@ -75,7 +77,9 @@ struct SpacetimeChristoffelFirstKind : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Abb<DataType, Dim, Frame>;
-  static std::string name() noexcept { return "SpactimeChristoffelSecondKind"; }
+  static std::string name() noexcept {
+    return "SpacetimeChristoffelSecondKind";
+  }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpatialChristoffelFirstKind : db::SimpleTag {
@@ -140,4 +144,22 @@ struct EnergyDensity : db::SimpleTag {
 };
 
 }  // namespace Tags
+
+/// The tags for the variables returned by GR analytic solutions.
+template <size_t Dim, typename DataType>
+using analytic_solution_tags = tmpl::list<
+    gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
+    ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>,
+                  Frame::Inertial>,
+    gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+    ::Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>,
+    ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial>,
+    gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+    ::Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>,
+    ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial>,
+    gr::Tags::SqrtDetSpatialMetric<DataType>,
+    gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>,
+    gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>>;
 }  // namespace gr

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -25,7 +25,13 @@ TimeStepper: RungeKutta3
 
 NumericalFluxParams:
 
-ReductionFileName: ReductionData
-VolumeFileName: VolumeData
+EventsAndTriggers:
+  ? EveryNSlabs:
+        N: 1
+        Offset: 0
+  : - ObserveNorms
+
+ReductionFileName: "./GHReductionData"
+VolumeFileName: "./GHVolumeData"
 ObserveNSlabs: 1
 ObserveAtT0: true

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -1,0 +1,31 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveGeneralizedHarmonic
+# Check: execute
+
+InitialTime: 0.0
+InitialTimeStep: 0.01
+FinalTime: 1
+
+DomainCreator:
+    Brick:
+      LowerBound: [4.0, -0.5, -0.5]
+      UpperBound: [5.0, 0.5, 0.5]
+      InitialRefinement: [1, 1, 1]
+      InitialGridPoints: [5, 5, 5]
+      IsPeriodicIn: [false, false, false]
+
+AnalyticSolution:
+    Mass: 1.0
+    Spin: [0.0, 0.0, 0.4]
+    Center: [0.0, 0.0, 0.0]
+
+TimeStepper: RungeKutta3
+
+NumericalFluxParams:
+
+ReductionFileName: ReductionData
+VolumeFileName: VolumeData
+ObserveNSlabs: 1
+ObserveAtT0: true

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Constraints.cpp
   Test_DuDt.cpp
   Test_Fluxes.cpp
+  Test_UpwindFlux.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -46,7 +46,7 @@
 
 namespace {
 template <size_t Index, size_t Dim, typename Frame>
-Scalar<DataVector> compute_speed_with_index(
+Scalar<DataVector> speed_with_index(
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& normal) {
@@ -58,16 +58,16 @@ Scalar<DataVector> compute_speed_with_index(
 template <size_t Dim, typename Frame>
 void test_characteristic_speeds() noexcept {
   const DataVector used_for_size(5);
-  pypp::check_with_random_values<1>(compute_speed_with_index<0, Dim, Frame>,
+  pypp::check_with_random_values<1>(speed_with_index<0, Dim, Frame>,
                                     "TestFunctions", "char_speed_upsi",
                                     {{{-10.0, 10.0}}}, used_for_size);
-  pypp::check_with_random_values<1>(compute_speed_with_index<1, Dim, Frame>,
+  pypp::check_with_random_values<1>(speed_with_index<1, Dim, Frame>,
                                     "TestFunctions", "char_speed_uzero",
                                     {{{-10.0, 10.0}}}, used_for_size);
-  pypp::check_with_random_values<1>(compute_speed_with_index<3, Dim, Frame>,
+  pypp::check_with_random_values<1>(speed_with_index<3, Dim, Frame>,
                                     "TestFunctions", "char_speed_uminus",
                                     {{{-10.0, 10.0}}}, used_for_size);
-  pypp::check_with_random_values<1>(compute_speed_with_index<2, Dim, Frame>,
+  pypp::check_with_random_values<1>(speed_with_index<2, Dim, Frame>,
                                     "TestFunctions", "char_speed_uplus",
                                     {{{-10.0, 10.0}}}, used_for_size);
 }
@@ -145,7 +145,7 @@ void test_characteristic_speeds_analytic(
 
 namespace {
 template <typename Tag, size_t Dim, typename Frame>
-typename Tag::type compute_field_with_tag(
+typename Tag::type field_with_tag(
     const Scalar<DataVector>& gamma_2,
     const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric,
     const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
@@ -163,25 +163,21 @@ void test_characteristic_fields() noexcept {
   const DataVector used_for_size(20);
   // UPsi
   pypp::check_with_random_values<1>(
-      compute_field_with_tag<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>, Dim,
-                             Frame>,
+      field_with_tag<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_upsi", {{{-100., 100.}}}, used_for_size);
   // UZero
   pypp::check_with_random_values<1>(
-      compute_field_with_tag<GeneralizedHarmonic::Tags::UZero<Dim, Frame>, Dim,
-                             Frame>,
+      field_with_tag<GeneralizedHarmonic::Tags::UZero<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uzero", {{{-100., 100.}}}, used_for_size,
       1.e-10);
   // UPlus
   pypp::check_with_random_values<1>(
-      compute_field_with_tag<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>, Dim,
-                             Frame>,
+      field_with_tag<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uplus", {{{-100., 100.}}}, used_for_size,
       1.e-11);
   // UMinus
   pypp::check_with_random_values<1>(
-      compute_field_with_tag<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>, Dim,
-                             Frame>,
+      field_with_tag<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "char_field_uminus", {{{-100., 100.}}}, used_for_size,
       1.e-10);
 }
@@ -321,7 +317,7 @@ void test_characteristic_fields_analytic(
 
 namespace {
 template <typename Tag, size_t Dim, typename Frame>
-typename Tag::type compute_evol_field_with_tag(
+typename Tag::type evol_field_with_tag(
     const Scalar<DataVector>& gamma_2,
     const tnsr::aa<DataVector, Dim, Frame>& u_psi,
     const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
@@ -339,18 +335,17 @@ void test_evolved_from_characteristic_fields() noexcept {
   const DataVector used_for_size(20);
   // Psi
   pypp::check_with_random_values<1>(
-      compute_evol_field_with_tag<gr::Tags::SpacetimeMetric<Dim, Frame>, Dim,
-                                  Frame>,
+      evol_field_with_tag<gr::Tags::SpacetimeMetric<Dim, Frame>, Dim, Frame>,
       "TestFunctions", "evol_field_psi", {{{-100., 100.}}}, used_for_size);
   // Pi
   pypp::check_with_random_values<1>(
-      compute_evol_field_with_tag<GeneralizedHarmonic::Tags::Pi<Dim, Frame>,
-                                  Dim, Frame>,
+      evol_field_with_tag<GeneralizedHarmonic::Tags::Pi<Dim, Frame>, Dim,
+                          Frame>,
       "TestFunctions", "evol_field_pi", {{{-100., 100.}}}, used_for_size);
   // Phi
   pypp::check_with_random_values<1>(
-      compute_evol_field_with_tag<GeneralizedHarmonic::Tags::Phi<Dim, Frame>,
-                                  Dim, Frame>,
+      evol_field_with_tag<GeneralizedHarmonic::Tags::Phi<Dim, Frame>, Dim,
+                          Frame>,
       "TestFunctions", "evol_field_phi", {{{-100., 100.}}}, used_for_size);
 }
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -8,20 +8,22 @@
 #include <limits>
 #include <memory>
 #include <pup.h>
+#include <string>
 
-#include "DataStructures/DataBox/Prefixes.hpp" // IWYU pragma: keep
-#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
@@ -40,6 +42,14 @@
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Variables
 // IWYU pragma: no_forward_declare Tags::deriv
+// IWYU pragma: no_forward_declare Tags::Coordinates
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct dt;
+}  // namespace Tags
+/// \endcond
 
 namespace {
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -660,16 +670,292 @@ void test_constraint_energy_analytic(const Solution& solution,
 
   auto constraint_energy = make_with_value<Scalar<DataVector>>(
       x, std::numeric_limits<double>::signaling_NaN());
-  GeneralizedHarmonic::constraint_energy(make_not_null(&constraint_energy),
-      gauge_constraint, f_constraint, two_index_constraint,
-      three_index_constraint, four_index_constraint, inverse_spatial_metric,
-      determinant_spatial_metric, 2.0, -3.0, 4.0, -5.0);
+  GeneralizedHarmonic::constraint_energy(
+      make_not_null(&constraint_energy), gauge_constraint, f_constraint,
+      two_index_constraint, three_index_constraint, four_index_constraint,
+      inverse_spatial_metric, determinant_spatial_metric, 2.0, -3.0, 4.0, -5.0);
 
   Approx numerical_approx =
       Approx::custom().epsilon(error_tolerance).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(
       constraint_energy, make_with_value<decltype(constraint_energy)>(x, 0.0),
       numerical_approx);
+}
+
+// Test compute items for various constraints via insertion and retrieval
+// in a databox
+template <typename Solution>
+void test_constraint_compute_items(
+    const Solution& solution, const size_t grid_size,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Check that compute items are named correctly
+  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma0Compute<
+            3, Frame::Inertial>::name() == "ConstraintGamma0");
+  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma1Compute<
+            3, Frame::Inertial>::name() == "ConstraintGamma1");
+  CHECK(GeneralizedHarmonic::Tags::ConstraintGamma2Compute<
+            3, Frame::Inertial>::name() == "ConstraintGamma2");
+  CHECK(GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
+            3, Frame::Inertial>::name() == "GaugeH");
+  CHECK(GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
+            3, Frame::Inertial>::name() == "SpacetimeDerivGaugeH");
+  CHECK(GeneralizedHarmonic::Tags::GaugeConstraintCompute<
+            3, Frame::Inertial>::name() == "GaugeConstraint");
+  CHECK(GeneralizedHarmonic::Tags::FConstraintCompute<
+            3, Frame::Inertial>::name() == "FConstraint");
+  CHECK(GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<
+            3, Frame::Inertial>::name() == "TwoIndexConstraint");
+  CHECK(GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<
+            3, Frame::Inertial>::name() == "ThreeIndexConstraint");
+  CHECK(GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
+            3, Frame::Inertial>::name() == "FourIndexConstraint");
+  CHECK(GeneralizedHarmonic::Tags::ConstraintEnergyCompute<
+            3, Frame::Inertial>::name() == "ConstraintEnergy");
+
+  // Check vs. time-independent analytic solution
+  // Set up grid
+  const size_t data_size = pow<3>(grid_size);
+  Mesh<3> mesh{grid_size, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto};
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
+          Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
+          Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& time_deriv_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& deriv_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<3>>(vars);
+  const auto& deriv_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& time_deriv_shift = get<Tags::dt<gr::Tags::Shift<3>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<3>>(vars);
+  const auto& time_deriv_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<3>>>(vars);
+  const auto& deriv_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Compute quantities from variables for the two-index constraint
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+  const auto spacetime_normal_one_form =
+      gr::spacetime_normal_one_form<3, Frame::Inertial, DataVector>(lapse);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+
+  const auto christoffel_first_kind =
+      gr::christoffel_first_kind(deriv_spatial_metric);
+  const auto trace_christoffel_first_kind =
+      trace_last_indices(christoffel_first_kind, inverse_spatial_metric);
+
+  // Compute derivatives d_phi, d_pi, and d_gauge_function numerically
+  // First, prepare
+  using VariablesTags =
+      tmpl::list<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>;
+
+  Variables<VariablesTags> gh_vars(data_size);
+  auto& pi = get<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>(gh_vars);
+  auto& phi = get<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(gh_vars);
+  auto& gauge_source =
+      get<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>(gh_vars);
+  phi = GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
+                                 spatial_metric, deriv_spatial_metric);
+  pi = GeneralizedHarmonic::pi(lapse, time_deriv_lapse, shift, time_deriv_shift,
+                               spatial_metric, time_deriv_spatial_metric, phi);
+  const auto extrinsic_curvature = GeneralizedHarmonic::extrinsic_curvature(
+      spacetime_normal_vector, pi, phi);
+  const auto trace_extrinsic_curvature =
+      trace(extrinsic_curvature, inverse_spatial_metric);
+  gauge_source = GeneralizedHarmonic::gauge_source(
+      lapse, time_deriv_lapse, deriv_lapse, shift, time_deriv_shift,
+      deriv_shift, spatial_metric, trace_extrinsic_curvature,
+      trace_christoffel_first_kind);
+  // Second, compute derivatives
+  const auto gh_derivs =
+      partial_derivatives<VariablesTags, VariablesTags, 3, Frame::Inertial>(
+          gh_vars, mesh, coord_map.inv_jacobian(x_logical));
+  const auto& deriv_pi =
+      get<Tags::deriv<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+  const auto& deriv_phi =
+      get<Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+  const auto& deriv_gauge_source =
+      get<Tags::deriv<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+
+  // Compute other derivatives
+  const auto derivatives_of_spacetime_metric =
+      gr::derivatives_of_spacetime_metric(
+          lapse, time_deriv_lapse, deriv_lapse, shift, time_deriv_shift,
+          deriv_shift, spatial_metric, time_deriv_spatial_metric,
+          deriv_spatial_metric);
+  const auto deriv_spacetime_metric =
+      GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<
+          3, Frame::Inertial>::function(derivatives_of_spacetime_metric);
+
+  auto time_deriv_gauge_source =
+      make_with_value<tnsr::a<DataVector, 3, Frame::Inertial>>(x, 0.);
+  get<0>(time_deriv_gauge_source) = 0.05;
+  get<1>(time_deriv_gauge_source) = 0.06;
+  get<2>(time_deriv_gauge_source) = 0.07;
+  get<3>(time_deriv_gauge_source) = -0.05;
+
+  const auto derivatives_of_gauge_source =
+      GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
+          3, Frame::Inertial>::function(time_deriv_gauge_source,
+                                        deriv_gauge_source);
+
+  // Insert into databox
+  const auto box = db::create<
+      db::AddSimpleTags<
+          ::Tags::Coordinates<3, Frame::Inertial>,
+          gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>,
+          ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+          ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>,
+          ::Tags::deriv<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::dt<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>,
+          ::Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::deriv<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>>,
+      db::AddComputeTags<
+          GeneralizedHarmonic::Tags::ConstraintGamma0Compute<3,
+                                                             Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ConstraintGamma1Compute<3,
+                                                             Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ConstraintGamma2Compute<3,
+                                                             Frame::Inertial>,
+          gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          gr::Tags::SpacetimeNormalVectorCompute<3,
+                                                 Frame::Inertial, DataVector>,
+          gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
+                                                      DataVector>,
+          gr::Tags::DetSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                       DataVector>,
+          gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                            DataVector>,
+          GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivativesOfSpacetimeMetricCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::GaugeConstraintCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::FConstraintCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3,
+                                                             Frame::Inertial>>>(
+      x, spatial_metric, lapse, shift, deriv_spatial_metric, deriv_lapse,
+      deriv_shift, time_deriv_spatial_metric, time_deriv_lapse,
+      time_deriv_shift, deriv_gauge_source, time_deriv_gauge_source, deriv_phi,
+      deriv_pi);
+
+  // Compute tested quantities locally
+  const auto gamma0 = GeneralizedHarmonic::Tags::ConstraintGamma0Compute<
+      3, Frame::Inertial>::function(x);
+  const auto gamma1 = GeneralizedHarmonic::Tags::ConstraintGamma1Compute<
+      3, Frame::Inertial>::function(x);
+  const auto gamma2 = GeneralizedHarmonic::Tags::ConstraintGamma2Compute<
+      3, Frame::Inertial>::function(x);
+
+  const auto four_idx_constraint =
+      GeneralizedHarmonic::four_index_constraint(deriv_phi);
+  const auto three_idx_constraint =
+      GeneralizedHarmonic::three_index_constraint(deriv_spacetime_metric, phi);
+  const auto two_idx_constraint = GeneralizedHarmonic::two_index_constraint(
+      deriv_gauge_source, spacetime_normal_one_form, spacetime_normal_vector,
+      inverse_spatial_metric, inverse_spacetime_metric, pi, phi, deriv_pi,
+      deriv_phi, gamma2, three_idx_constraint);
+  const auto gauge_constraint = GeneralizedHarmonic::gauge_constraint(
+      gauge_source, spacetime_normal_one_form, spacetime_normal_vector,
+      inverse_spatial_metric, inverse_spacetime_metric, pi, phi);
+  const auto f_constraint = GeneralizedHarmonic::f_constraint(
+      gauge_source, deriv_gauge_source, spacetime_normal_one_form,
+      spacetime_normal_vector, inverse_spatial_metric, inverse_spacetime_metric,
+      pi, phi, deriv_pi, deriv_phi, gamma2, three_idx_constraint);
+  const auto constraint_energy = GeneralizedHarmonic::constraint_energy(
+      gauge_constraint, f_constraint, two_idx_constraint, three_idx_constraint,
+      four_idx_constraint, inverse_spatial_metric, det_spatial_metric);
+
+  // Check that their compute items in databox furnish identical values
+  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma0>(box) == gamma0);
+  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma1>(box) == gamma1);
+  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma2>(box) == gamma2);
+  CHECK(db::get<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>(box) ==
+        gauge_source);
+  CHECK(
+      db::get<
+          GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<3, Frame::Inertial>>(
+          box) == derivatives_of_gauge_source);
+  CHECK(db::get<
+            GeneralizedHarmonic::Tags::FourIndexConstraint<3, Frame::Inertial>>(
+            box) == four_idx_constraint);
+  CHECK(
+      db::get<
+          GeneralizedHarmonic::Tags::ThreeIndexConstraint<3, Frame::Inertial>>(
+          box) == three_idx_constraint);
+  CHECK(db::get<
+            GeneralizedHarmonic::Tags::TwoIndexConstraint<3, Frame::Inertial>>(
+            box) == two_idx_constraint);
+  CHECK(db::get<GeneralizedHarmonic::Tags::GaugeConstraint<3, Frame::Inertial>>(
+            box) == gauge_constraint);
+  CHECK(db::get<GeneralizedHarmonic::Tags::FConstraint<3, Frame::Inertial>>(
+            box) == f_constraint);
+  CHECK(
+      db::get<GeneralizedHarmonic::Tags::ConstraintEnergy<3, Frame::Inertial>>(
+          box) == constraint_energy);
 }
 }  // namespace
 
@@ -930,4 +1216,23 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintEnergy",
       std::numeric_limits<double>::signaling_NaN());
   test_constraint_energy_random<3, Frame::Inertial, double>(
       std::numeric_limits<double>::signaling_NaN());
+}
+
+// [[TimeOut, 7]]
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintComputeTags",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/"};
+  // Test the F constraint against Kerr Schild
+  const double mass = 1.4;
+  const std::array<double, 3> dimensionless_spin{{0.4, 0.3, 0.2}};
+  const std::array<double, 3> center{{0.2, 0.3, 0.4}};
+  const gr::Solutions::KerrSchild solution(mass, dimensionless_spin, center);
+
+  const size_t grid_size = 8;
+  const std::array<double, 3> upper_bound{{0.82, 1.24, 1.32}};
+  const std::array<double, 3> lower_bound{{0.8, 1.22, 1.30}};
+
+  test_constraint_compute_items(solution, grid_size, lower_bound, upper_bound);
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
@@ -1,0 +1,226 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/StrahlkorperGr.hpp"
+#include "ApparentHorizons/Tags.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"        // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::Pi
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::Phi
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPsi
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UZero
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UMinus
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPlus
+// IWYU pragma: no_forward_declare StrahlkorperTags::CartesianCoords
+// IWYU pragma: no_forward_declare StrahlkorperTags::NormalOneForm
+// IWYU pragma: no_forward_declare Tags::CharSpeed
+// IWYU pragma: no_forward_declare Tags::dt
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+
+namespace {
+template <class... Tags, class FluxType, class... NormalDotNumericalFluxTypes>
+void apply_numerical_flux(
+    const FluxType& flux,
+    const Variables<tmpl::list<Tags...>>& packaged_data_int,
+    const Variables<tmpl::list<Tags...>>& packaged_data_ext,
+    NormalDotNumericalFluxTypes&&... normal_dot_numerical_flux) {
+  flux(std::forward<NormalDotNumericalFluxTypes>(normal_dot_numerical_flux)...,
+       get<Tags>(packaged_data_int)..., get<Tags>(packaged_data_ext)...);
+}
+
+// Test GH upwind flux by comparing to Schwarzschild
+template <typename Solution>
+void test_upwind_flux_analytic(
+    const Solution& solution_int, const Solution& solution_ext,
+    const Strahlkorper<Frame::Inertial>& strahlkorper) noexcept {
+  // Set up grid
+  const size_t spatial_dim = 3;
+
+  const auto box = db::create<
+      db::AddSimpleTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+      db::AddComputeTags<
+          StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(strahlkorper);
+
+  const auto& x =
+      db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Evaluate analytic solution for interior
+  const auto vars_int = solution_int.variables(
+      x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse_int = get<gr::Tags::Lapse<>>(vars_int);
+  const auto& dt_lapse_int = get<Tags::dt<gr::Tags::Lapse<>>>(vars_int);
+  const auto& d_lapse_int =
+      get<typename Solution::template DerivLapse<DataVector>>(vars_int);
+  const auto& shift_int = get<gr::Tags::Shift<spatial_dim>>(vars_int);
+  const auto& d_shift_int =
+      get<typename Solution::template DerivShift<DataVector>>(vars_int);
+  const auto& dt_shift_int =
+      get<Tags::dt<gr::Tags::Shift<spatial_dim>>>(vars_int);
+  const auto& spatial_metric_int =
+      get<gr::Tags::SpatialMetric<spatial_dim>>(vars_int);
+  const auto& dt_spatial_metric_int =
+      get<Tags::dt<gr::Tags::SpatialMetric<spatial_dim>>>(vars_int);
+  const auto& d_spatial_metric_int =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars_int);
+
+  const auto inverse_spatial_metric_int =
+      determinant_and_inverse(spatial_metric_int).second;
+  const auto spacetime_metric_int =
+      gr::spacetime_metric(lapse_int, shift_int, spatial_metric_int);
+  const auto phi_int =
+      GeneralizedHarmonic::phi(lapse_int, d_lapse_int, shift_int, d_shift_int,
+                               spatial_metric_int, d_spatial_metric_int);
+  const auto pi_int = GeneralizedHarmonic::pi(
+      lapse_int, dt_lapse_int, shift_int, dt_shift_int, spatial_metric_int,
+      dt_spatial_metric_int, phi_int);
+
+  // Evaluate analytic solution for exterior (i.e. neighbor)
+  const auto vars_ext = solution_ext.variables(
+      x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse_ext = get<gr::Tags::Lapse<>>(vars_ext);
+  const auto& dt_lapse_ext = get<Tags::dt<gr::Tags::Lapse<>>>(vars_ext);
+  const auto& d_lapse_ext =
+      get<typename Solution::template DerivLapse<DataVector>>(vars_ext);
+  const auto& shift_ext = get<gr::Tags::Shift<spatial_dim>>(vars_ext);
+  const auto& d_shift_ext =
+      get<typename Solution::template DerivShift<DataVector>>(vars_ext);
+  const auto& dt_shift_ext =
+      get<Tags::dt<gr::Tags::Shift<spatial_dim>>>(vars_ext);
+  const auto& spatial_metric_ext =
+      get<gr::Tags::SpatialMetric<spatial_dim>>(vars_ext);
+  const auto& dt_spatial_metric_ext =
+      get<Tags::dt<gr::Tags::SpatialMetric<spatial_dim>>>(vars_ext);
+  const auto& d_spatial_metric_ext =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars_ext);
+
+  const auto inverse_spatial_metric_ext =
+      determinant_and_inverse(spatial_metric_ext).second;
+  const auto spacetime_metric_ext =
+      gr::spacetime_metric(lapse_ext, shift_ext, spatial_metric_ext);
+  const auto phi_ext =
+      GeneralizedHarmonic::phi(lapse_ext, d_lapse_ext, shift_ext, d_shift_ext,
+                               spatial_metric_ext, d_spatial_metric_ext);
+  const auto pi_ext = GeneralizedHarmonic::pi(
+      lapse_ext, dt_lapse_ext, shift_ext, dt_shift_ext, spatial_metric_ext,
+      dt_spatial_metric_ext, phi_ext);
+
+  // More ingredients to get the char fields
+  const size_t n_pts = x.begin()->size();
+  const auto gamma_1 = make_with_value<Scalar<DataVector>>(x, 0.4);
+  const auto gamma_2 = make_with_value<Scalar<DataVector>>(x, 0.1);
+
+  // Get surface normal vectors
+  const DataVector one_over_one_form_magnitude_int =
+      1.0 / get(magnitude(
+                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric_int));
+  const auto unit_normal_one_form_int = StrahlkorperGr::unit_normal_one_form(
+      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+      one_over_one_form_magnitude_int);
+  const auto unit_normal_vector_int = raise_or_lower_index(
+      unit_normal_one_form_int, inverse_spatial_metric_int);
+
+  // Get the characteristic fields and speeds
+  const auto char_fields_int = GeneralizedHarmonic::CharacteristicFieldsCompute<
+      spatial_dim, Frame::Inertial>::function(gamma_2,
+                                              inverse_spatial_metric_int,
+                                              spacetime_metric_int, pi_int,
+                                              phi_int,
+                                              unit_normal_one_form_int);
+  const auto char_fields_ext = GeneralizedHarmonic::CharacteristicFieldsCompute<
+      spatial_dim, Frame::Inertial>::function(gamma_2,
+                                              inverse_spatial_metric_ext,
+                                              spacetime_metric_ext, pi_ext,
+                                              phi_ext,
+                                              unit_normal_one_form_int);
+
+  const auto one = make_with_value<Scalar<DataVector>>(x, 1.0);
+  const auto minus_one = make_with_value<Scalar<DataVector>>(x, -1.0);
+  const auto five = make_with_value<Scalar<DataVector>>(x, 5.0);
+  const auto minus_five = make_with_value<Scalar<DataVector>>(x, -5.0);
+
+  std::array<DataVector, 4> char_speeds_one{
+      {get(one), get(one), get(one), get(one)}};
+  std::array<DataVector, 4> char_speeds_minus_one{
+      {get(minus_one), get(minus_one), get(minus_one), get(minus_one)}};
+  std::array<DataVector, 4> char_speeds_five{
+      {get(five), get(five), get(five), get(five)}};
+  std::array<DataVector, 4> char_speeds_minus_five{
+      {get(minus_five), get(minus_five), get(minus_five), get(minus_five)}};
+
+  GeneralizedHarmonic::UpwindFlux<spatial_dim> flux_computer{};
+
+  // If all the char speeds are +1, the weighted fields should just
+  // be the interior fields
+  const auto weighted_char_fields_one = flux_computer.weight_char_fields(
+      char_fields_int, char_speeds_one, char_fields_ext, char_speeds_one);
+  CHECK(weighted_char_fields_one == char_fields_int);
+
+  // If all the char speeds are -1, the weighted fields should just be
+  // the exterior fields up to a sign
+  const auto weighted_char_fields_minus_one =
+      flux_computer.weight_char_fields(char_fields_int, char_speeds_minus_one,
+                                       char_fields_ext, char_speeds_minus_one);
+  CHECK(weighted_char_fields_minus_one == -1.0 * char_fields_ext);
+
+  // Check scaling by 5 instead of 1
+  const auto weighted_char_fields_minus_five =
+      flux_computer.weight_char_fields(char_fields_int, char_speeds_minus_five,
+                                       char_fields_ext, char_speeds_minus_five);
+  const auto weighted_char_fields_five = flux_computer.weight_char_fields(
+      char_fields_int, char_speeds_five, char_fields_ext, char_speeds_five);
+  CHECK(weighted_char_fields_minus_five == -5.0 * char_fields_ext);
+  CHECK(weighted_char_fields_five == 5.0 * char_fields_int);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.UpwindFlux",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/"};
+
+  // Test GH upwind flux against Kerr Schild
+  const double mass = 2.;
+  const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  const gr::Solutions::KerrSchild solution_1(mass, spin, center);
+  const gr::Solutions::KerrSchild solution_2(2.0 * mass, spin, center);
+
+  const std::array<double, 3> lower_bound{{0.82, 1.22, 1.32}};
+  const std::array<double, 3> upper_bound{{0.78, 1.18, 1.28}};
+
+  const double radius_inside_horizons = 1.0;
+  const size_t l_max = 2;
+
+  const auto strahlkorper_inside_horizons = Strahlkorper<Frame::Inertial>(
+      l_max, l_max, radius_inside_horizons, center);
+
+  test_upwind_flux_analytic(solution_1, solution_2,
+                            strahlkorper_inside_horizons);
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_KerrSchild.cpp
   Test_Minkowski.cpp
   Test_Tov.cpp
+  Test_WrapGh.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_WrapGh.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_WrapGh.cpp
@@ -1,0 +1,266 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrapGh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tags::deriv
+
+namespace {
+template <typename SolutionType>
+void test_generalized_harmonic_solution(
+    const SolutionType& solution,
+    const GeneralizedHarmonic::Solutions::WrapGh<SolutionType>
+        wrapped_solution) {
+  const DataVector data_vector{5.0, 4.0};
+  const tnsr::I<DataVector, wrapped_solution.volume_dim, Frame::Inertial> x{
+      data_vector};
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Get quantities from an analytic solution of Einstein's equations
+  const auto vars = solution.variables(
+      x, t, typename SolutionType::template tags<DataVector>{});
+  const auto lapse = get<gr::Tags::Lapse<DataVector>>(vars);
+  const auto dt_lapse = get<Tags::dt<gr::Tags::Lapse<DataVector>>>(vars);
+  const auto d_lapse = get<
+      Tags::deriv<gr::Tags::Lapse<DataVector>,
+                  tmpl::size_t<wrapped_solution.volume_dim>, Frame::Inertial>>(
+      vars);
+  const auto shift = get<gr::Tags::Shift<wrapped_solution.volume_dim,
+                                         Frame::Inertial, DataVector>>(vars);
+  const auto dt_shift =
+      get<Tags::dt<gr::Tags::Shift<wrapped_solution.volume_dim, Frame::Inertial,
+                                   DataVector>>>(vars);
+  const auto d_shift = get<Tags::deriv<
+      gr::Tags::Shift<wrapped_solution.volume_dim, Frame::Inertial, DataVector>,
+      tmpl::size_t<wrapped_solution.volume_dim>, Frame::Inertial>>(vars);
+  const auto g =
+      get<gr::Tags::SpatialMetric<wrapped_solution.volume_dim, Frame::Inertial,
+                                  DataVector>>(vars);
+  const auto dt_g =
+      get<Tags::dt<gr::Tags::SpatialMetric<wrapped_solution.volume_dim,
+                                           Frame::Inertial, DataVector>>>(vars);
+  const auto d_g = get<
+      Tags::deriv<gr::Tags::SpatialMetric<wrapped_solution.volume_dim,
+                                          Frame::Inertial, DataVector>,
+                  tmpl::size_t<wrapped_solution.volume_dim>, Frame::Inertial>>(
+      vars);
+  const auto inv_g =
+      get<gr::Tags::InverseSpatialMetric<wrapped_solution.volume_dim,
+                                         Frame::Inertial, DataVector>>(vars);
+  const auto extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<wrapped_solution.volume_dim,
+                                       Frame::Inertial, DataVector>>(vars);
+  const auto sqrt_det_g = get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(vars);
+
+  // Get quantities from the same solution, wrapped in a
+  // WrapGh
+  const auto wrapped_lapse =
+      get<gr::Tags::Lapse<DataVector>>(wrapped_solution.variables(
+          x, t, tmpl::list<gr::Tags::Lapse<DataVector>>{}));
+  const auto wrapped_dt_lapse =
+      get<Tags::dt<gr::Tags::Lapse<DataVector>>>(wrapped_solution.variables(
+          x, t, tmpl::list<Tags::dt<gr::Tags::Lapse<DataVector>>>{}));
+  const auto wrapped_d_lapse = get<
+      Tags::deriv<gr::Tags::Lapse<DataVector>,
+                  tmpl::size_t<wrapped_solution.volume_dim>, Frame::Inertial>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<Tags::deriv<gr::Tags::Lapse<DataVector>,
+                                 tmpl::size_t<wrapped_solution.volume_dim>,
+                                 Frame::Inertial>>{}));
+  const auto wrapped_shift = get<gr::Tags::Shift<wrapped_solution.volume_dim,
+                                                 Frame::Inertial, DataVector>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<gr::Tags::Shift<wrapped_solution.volume_dim,
+                                     Frame::Inertial, DataVector>>{}));
+  const auto wrapped_dt_shift = get<Tags::dt<gr::Tags::Shift<
+      wrapped_solution.volume_dim, Frame::Inertial, DataVector>>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<Tags::dt<gr::Tags::Shift<
+              wrapped_solution.volume_dim, Frame::Inertial, DataVector>>>{}));
+  const auto wrapped_d_shift = get<Tags::deriv<
+      gr::Tags::Shift<wrapped_solution.volume_dim, Frame::Inertial, DataVector>,
+      tmpl::size_t<wrapped_solution.volume_dim>, Frame::Inertial>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<Tags::deriv<gr::Tags::Shift<wrapped_solution.volume_dim,
+                                                 Frame::Inertial, DataVector>,
+                                 tmpl::size_t<wrapped_solution.volume_dim>,
+                                 Frame::Inertial>>{}));
+  const auto wrapped_g = get<gr::Tags::SpatialMetric<
+      wrapped_solution.volume_dim, Frame::Inertial, DataVector>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<gr::Tags::SpatialMetric<wrapped_solution.volume_dim,
+                                             Frame::Inertial, DataVector>>{}));
+  const auto wrapped_dt_g = get<Tags::dt<gr::Tags::SpatialMetric<
+      wrapped_solution.volume_dim, Frame::Inertial, DataVector>>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<Tags::dt<gr::Tags::SpatialMetric<
+              wrapped_solution.volume_dim, Frame::Inertial, DataVector>>>{}));
+  const auto wrapped_d_g = get<
+      Tags::deriv<gr::Tags::SpatialMetric<wrapped_solution.volume_dim,
+                                          Frame::Inertial, DataVector>,
+                  tmpl::size_t<wrapped_solution.volume_dim>, Frame::Inertial>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<Tags::deriv<
+              gr::Tags::SpatialMetric<wrapped_solution.volume_dim,
+                                      Frame::Inertial, DataVector>,
+              tmpl::size_t<wrapped_solution.volume_dim>, Frame::Inertial>>{}));
+  const auto wrapped_inv_g = get<gr::Tags::InverseSpatialMetric<
+      wrapped_solution.volume_dim, Frame::Inertial, DataVector>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<gr::Tags::InverseSpatialMetric<
+              wrapped_solution.volume_dim, Frame::Inertial, DataVector>>{}));
+  const auto wrapped_extrinsic_curvature = get<gr::Tags::ExtrinsicCurvature<
+      wrapped_solution.volume_dim, Frame::Inertial, DataVector>>(
+      wrapped_solution.variables(
+          x, t,
+          tmpl::list<gr::Tags::ExtrinsicCurvature<
+              wrapped_solution.volume_dim, Frame::Inertial, DataVector>>{}));
+  const auto wrapped_sqrt_det_g =
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(
+          wrapped_solution.variables(
+              x, t, tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataVector>>{}));
+
+  // Check that the solution and the wrapped solution returned the same
+  // results
+  CHECK(lapse == wrapped_lapse);
+  CHECK(dt_lapse == wrapped_dt_lapse);
+  CHECK(d_lapse == wrapped_d_lapse);
+
+  CHECK(shift == wrapped_shift);
+  CHECK(dt_shift == wrapped_dt_shift);
+  CHECK(d_shift == wrapped_d_shift);
+
+  CHECK(g == wrapped_g);
+  CHECK(dt_g == wrapped_dt_g);
+  CHECK(d_g == wrapped_d_g);
+
+  // Check that the wrapped solution returns the correct psi, pi, phi
+  const auto psi = gr::spacetime_metric(lapse, shift, g);
+  const auto phi =
+      GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift, g, d_g);
+  const auto pi =
+      GeneralizedHarmonic::pi(lapse, dt_lapse, shift, dt_shift, g, dt_g, phi);
+
+  const auto wrapped_gh_vars = wrapped_solution.variables(
+      x, t,
+      tmpl::list<gr::Tags::SpacetimeMetric<wrapped_solution.volume_dim,
+                                           Frame::Inertial, DataVector>,
+                 GeneralizedHarmonic::Tags::Pi<wrapped_solution.volume_dim,
+                                               Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<wrapped_solution.volume_dim,
+                                                Frame::Inertial>>{});
+  CHECK(psi == get<gr::Tags::SpacetimeMetric<wrapped_solution.volume_dim,
+                                             Frame::Inertial, DataVector>>(
+                   wrapped_gh_vars));
+  CHECK(pi ==
+        get<GeneralizedHarmonic::Tags::Pi<wrapped_solution.volume_dim,
+                                          Frame::Inertial>>(wrapped_gh_vars));
+  CHECK(phi ==
+        get<GeneralizedHarmonic::Tags::Phi<wrapped_solution.volume_dim,
+                                           Frame::Inertial>>(wrapped_gh_vars));
+
+  test_serialization(wrapped_solution);
+  // test operator !=
+  CHECK_FALSE(wrapped_solution != wrapped_solution);
+}
+
+struct WrapGh {
+  using type =
+      GeneralizedHarmonic::Solutions::WrapGh<gr::Solutions::KerrSchild>;
+  static constexpr OptionString help{"A wrapped generalized harmonic solution"};
+};
+
+void test_construct_from_options() {
+  Options<tmpl::list<WrapGh>> opts("");
+  opts.parse(
+      "WrapGh:\n"
+      "  Mass: 0.5\n"
+      "  Spin: [0.1,0.2,0.3]\n"
+      "  Center: [1.0,3.0,2.0]");
+  const double mass = 0.5;
+  const std::array<double, 3> spin{{0.1, 0.2, 0.3}};
+  const std::array<double, 3> center{{1.0, 3.0, 2.0}};
+  CHECK(opts.get<WrapGh>() ==
+        GeneralizedHarmonic::Solutions::WrapGh<gr::Solutions::KerrSchild>(
+            mass, spin, center));
+}
+
+template <typename SolutionType>
+void test_copy_and_move(const SolutionType& solution) noexcept {
+  test_copy_semantics(solution);
+  auto solution_copy = solution;
+  auto solution_copy2 = solution;
+  // clang-tidy: std::move of trivially copyable type
+  test_move_semantics(std::move(solution_copy2), solution_copy);  // NOLINT
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.WrapGh",
+                  "[PointwiseFunctions][Unit]") {
+  gr::Solutions::Minkowski<1> minkowski1{};
+  gr::Solutions::Minkowski<2> minkowski2{};
+  gr::Solutions::Minkowski<3> minkowski3{};
+
+  const double mass = 0.5;
+  const std::array<double, 3> spin{{0.1, 0.2, 0.3}};
+  const std::array<double, 3> center{{1.0, 3.0, 2.0}};
+  gr::Solutions::KerrSchild kerr_schild(mass, spin, center);
+
+  GeneralizedHarmonic::Solutions::WrapGh<gr::Solutions::Minkowski<1>>
+      wrapped_minkowski1{};
+  GeneralizedHarmonic::Solutions::WrapGh<gr::Solutions::Minkowski<2>>
+      wrapped_minkowski2{};
+  GeneralizedHarmonic::Solutions::WrapGh<gr::Solutions::Minkowski<3>>
+      wrapped_minkowski3{};
+  GeneralizedHarmonic::Solutions::WrapGh<gr::Solutions::KerrSchild>
+      wrapped_kerr_schild(mass, spin, center);
+
+  test_generalized_harmonic_solution<gr::Solutions::Minkowski<1>>(
+      minkowski1, wrapped_minkowski1);
+  test_generalized_harmonic_solution<gr::Solutions::Minkowski<2>>(
+      minkowski2, wrapped_minkowski2);
+  test_generalized_harmonic_solution<gr::Solutions::Minkowski<3>>(
+      minkowski3, wrapped_minkowski3);
+  test_generalized_harmonic_solution<gr::Solutions::KerrSchild>(
+      kerr_schild, wrapped_kerr_schild);
+
+  test_serialization(wrapped_minkowski1);
+  test_serialization(wrapped_minkowski2);
+  test_serialization(wrapped_minkowski3);
+  test_serialization(wrapped_kerr_schild);
+
+  test_copy_and_move(wrapped_minkowski1);
+  test_copy_and_move(wrapped_minkowski2);
+  test_copy_and_move(wrapped_minkowski3);
+  test_copy_and_move(wrapped_kerr_schild);
+
+  test_construct_from_options();
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -3,13 +3,39 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <array>
 #include <cstddef>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+/// \cond
+namespace GeneralizedHarmonic {
+namespace Tags {
+template <size_t SpatialDim, typename Frame>
+struct DerivativesOfSpacetimeMetricCompute;
+}  // namespace Tags
+}  // namespace GeneralizedHarmonic
+namespace Tags {
+template <typename Tag, typename Dim, typename Frame, typename>
+struct deriv;
+}  // namespace Tags
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+/// \endcond
 
 namespace {
 template <size_t Dim, IndexType Index, typename DataType>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -18,7 +18,7 @@ void test_christoffel(const DataType& used_for_size) {
       const tnsr::abb<DataType, Dim, Frame::Inertial, Index>&) =
       &gr::christoffel_first_kind<Dim, Frame::Inertial, Index, DataType>;
   pypp::check_with_random_values<1>(f, "Christoffel", "christoffel_first_kind",
-                                    {{{-10.0, 10.0}}}, used_for_size);
+                                    {{{-10., 10.}}}, used_for_size);
 }
 }  // namespace
 
@@ -39,4 +39,165 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel.",
   test_christoffel<1, IndexType::Spacetime>(0.);
   test_christoffel<2, IndexType::Spacetime>(0.);
   test_christoffel<3, IndexType::Spacetime>(0.);
+
+  // Check that the compute items return correct values
+  const DataVector test_vector{5., 4.};
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(spatial_metric) = 1.5;
+  get<0, 1>(spatial_metric) = 0.1;
+  get<0, 2>(spatial_metric) = 0.2;
+  get<1, 1>(spatial_metric) = 1.4;
+  get<1, 2>(spatial_metric) = 0.2;
+  get<2, 2>(spatial_metric) = 1.3;
+
+  auto lapse = make_with_value<Scalar<DataVector>>(test_vector, 0.94);
+
+  auto shift =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(shift) = 0.5;
+  get<1>(shift) = 0.6;
+  get<2>(shift) = 0.7;
+
+  auto dt_spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(dt_spatial_metric) = 0.05;
+  get<0, 1>(dt_spatial_metric) = 0.01;
+  get<0, 2>(dt_spatial_metric) = 0.02;
+  get<1, 1>(dt_spatial_metric) = 0.04;
+  get<1, 2>(dt_spatial_metric) = 0.02;
+  get<2, 2>(dt_spatial_metric) = 0.03;
+
+  auto dt_lapse = make_with_value<Scalar<DataVector>>(test_vector, 0.);
+  get(dt_lapse) = 0.04;
+
+  auto dt_shift =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(dt_shift) = 0.05;
+  get<1>(dt_shift) = 0.06;
+  get<2>(dt_shift) = 0.07;
+
+  auto deriv_spatial_metric =
+      make_with_value<tnsr::ijj<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                 0.);
+  get<0, 0, 0>(deriv_spatial_metric) = 0.1;
+  get<0, 0, 1>(deriv_spatial_metric) = 0.2;
+  get<0, 0, 2>(deriv_spatial_metric) = 0.3;
+  get<0, 1, 1>(deriv_spatial_metric) = 0.2;
+  get<0, 1, 2>(deriv_spatial_metric) = 0.1;
+  get<0, 2, 2>(deriv_spatial_metric) = 0.2;
+  get<1, 0, 0>(deriv_spatial_metric) = 0.3;
+  get<1, 0, 1>(deriv_spatial_metric) = 0.2;
+  get<1, 0, 2>(deriv_spatial_metric) = 0.1;
+  get<1, 1, 1>(deriv_spatial_metric) = 0.2;
+  get<1, 1, 2>(deriv_spatial_metric) = 0.3;
+  get<1, 2, 2>(deriv_spatial_metric) = 0.2;
+  get<2, 0, 0>(deriv_spatial_metric) = -0.1;
+  get<2, 0, 1>(deriv_spatial_metric) = -0.2;
+  get<2, 0, 2>(deriv_spatial_metric) = -0.3;
+  get<2, 1, 1>(deriv_spatial_metric) = -0.2;
+  get<2, 1, 2>(deriv_spatial_metric) = -0.1;
+  get<2, 2, 2>(deriv_spatial_metric) = -0.2;
+
+  auto deriv_lapse =
+      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(deriv_lapse) = -0.1;
+  get<1>(deriv_lapse) = -0.2;
+  get<2>(deriv_lapse) = -0.3;
+
+  auto deriv_shift = make_with_value<tnsr::iJ<DataVector, 3, Frame::Inertial>>(
+      test_vector, 0.);
+  get<0, 0>(deriv_shift) = -0.05;
+  get<0, 1>(deriv_shift) = 0.06;
+  get<0, 2>(deriv_shift) = 0.07;
+  get<1, 0>(deriv_shift) = -0.03;
+  get<1, 1>(deriv_shift) = 0.04;
+  get<1, 2>(deriv_shift) = 0.03;
+  get<2, 0>(deriv_shift) = 0.01;
+  get<2, 1>(deriv_shift) = 0.02;
+  get<2, 2>(deriv_shift) = -0.01;
+
+  const auto& derivatives_of_spacetime_metric =
+      gr::derivatives_of_spacetime_metric(
+          lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
+          spatial_metric, dt_spatial_metric, deriv_spatial_metric);
+
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto& inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+
+  const auto& spacetime_christoffel_first_kind =
+      gr::christoffel_first_kind(derivatives_of_spacetime_metric);
+  const auto& trace_spacetime_christoffel_first_kind = trace_last_indices(
+      spacetime_christoffel_first_kind, inverse_spacetime_metric);
+  const auto& spatial_christoffel_first_kind =
+      gr::christoffel_first_kind(deriv_spatial_metric);
+  const auto& trace_spatial_christoffel_first_kind = trace_last_indices(
+      spatial_christoffel_first_kind, inverse_spatial_metric);
+  const auto& spacetime_christoffel_second_kind = raise_or_lower_first_index(
+      spacetime_christoffel_first_kind, inverse_spacetime_metric);
+  const auto& spatial_christoffel_second_kind = raise_or_lower_first_index(
+      spatial_christoffel_first_kind, inverse_spatial_metric);
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>,
+          ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+          ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>,
+      db::AddComputeTags<
+          gr::Tags::SpacetimeMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
+                                                      DataVector>,
+          gr::Tags::SqrtDetSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          GeneralizedHarmonic::Tags::DerivativesOfSpacetimeMetricCompute<
+              3, Frame::Inertial>,
+          gr::Tags::SpacetimeChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                         DataVector>,
+          gr::Tags::TraceSpacetimeChristoffelFirstKindCompute<
+              3, Frame::Inertial, DataVector>,
+          gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                       DataVector>,
+          gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                            DataVector>,
+          gr::Tags::SpacetimeChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                          DataVector>,
+          gr::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial,
+                                                        DataVector>  //,
+
+          >>(spatial_metric, lapse, shift, deriv_spatial_metric, deriv_lapse,
+             deriv_shift, dt_spatial_metric, dt_lapse, dt_shift);
+
+  CHECK(db::get<gr::Tags::SpacetimeChristoffelFirstKind<3, Frame::Inertial,
+                                                        DataVector>>(box) ==
+        spacetime_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::TraceSpacetimeChristoffelFirstKind<3, Frame::Inertial,
+                                                             DataVector>>(
+            box) == trace_spacetime_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::SpatialChristoffelFirstKind<3, Frame::Inertial,
+                                                      DataVector>>(box) ==
+        spatial_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::TraceSpatialChristoffelFirstKind<3, Frame::Inertial,
+                                                           DataVector>>(box) ==
+        trace_spatial_christoffel_first_kind);
+  CHECK(db::get<gr::Tags::SpacetimeChristoffelSecondKind<3, Frame::Inertial,
+                                                         DataVector>>(box) ==
+        spacetime_christoffel_second_kind);
+  CHECK(db::get<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
+                                                       DataVector>>(box) ==
+        spatial_christoffel_second_kind);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -9,7 +9,10 @@
 #include <memory>
 #include <pup.h>
 #include <random>
+#include <string>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -20,6 +23,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
@@ -37,6 +41,13 @@
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace Tags {
+template <typename Tag, typename Dim, typename Frame, typename>
+struct deriv;
+}  // namespace Tags
+/// \endcond
 
 namespace {
 using Affine = domain::CoordinateMaps::Affine;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -19,6 +19,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
@@ -28,6 +29,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
@@ -98,7 +100,7 @@ void test_compute_extrinsic_curvature_and_deriv_metric(const T& used_for_size) {
     // Make sure spatial_metric isn't singular by adding
     // large enough positive diagonal values.
     for (size_t i = 0; i < Dim; ++i) {
-      spatial_metric_l.get(i, i) += 4.0;
+      spatial_metric_l.get(i, i) += 4.;
     }
     return spatial_metric_l;
   }();
@@ -176,7 +178,7 @@ void test_gij_deriv_functions(const DataVector& used_for_size) noexcept {
           &::GeneralizedHarmonic::time_deriv_of_spatial_metric<
               SpatialDim, Frame, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "dt_spatial_metric",
-      {{{std::numeric_limits<double>::denorm_min(), 10.0}}}, used_for_size);
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
   // spacetime_deriv_of_det_spatial_metric
   pypp::check_with_random_values<1>(
       static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
@@ -186,7 +188,7 @@ void test_gij_deriv_functions(const DataVector& used_for_size) noexcept {
           &::GeneralizedHarmonic::spacetime_deriv_of_det_spatial_metric<
               SpatialDim, Frame, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "spacetime_deriv_detg",
-      {{{std::numeric_limits<double>::denorm_min(), 10.0}}}, used_for_size);
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
 }
 
 // Test computation of derivs of lapse by comparing to Kerr-Schild
@@ -574,4 +576,234 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
                                     upper_bound);
   test_shift_deriv_functions_analytic(solution, grid_size, lower_bound,
                                       upper_bound);
+
+  // Check that compute items work correctly in the DataBox
+  // First, check that the names are correct
+  CHECK(GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>::name() ==
+        "Phi");
+  CHECK(GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>::name() ==
+        "Pi");
+  CHECK(GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+            3, Frame::Inertial>::name() == "TraceExtrinsicCurvature");
+  CHECK(GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<
+            3, Frame::Inertial>::name() == "ExtrinsicCurvature");
+  CHECK(GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<
+            3, Frame::Inertial>::name() == "deriv(SpatialMetric)");
+  CHECK(GeneralizedHarmonic::Tags::DerivLapseCompute<3,
+                                                     Frame::Inertial>::name() ==
+        "deriv(Lapse)");
+  CHECK(GeneralizedHarmonic::Tags::DerivShiftCompute<3,
+                                                     Frame::Inertial>::name() ==
+        "deriv(Shift)");
+  CHECK(GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<
+            3, Frame::Inertial>::name() == "dt(SpatialMetric)");
+  CHECK(GeneralizedHarmonic::Tags::TimeDerivLapseCompute<
+            3, Frame::Inertial>::name() == "dt(Lapse)");
+  CHECK(GeneralizedHarmonic::Tags::TimeDerivShiftCompute<
+            3, Frame::Inertial>::name() == "dt(Shift)");
+  CHECK(GeneralizedHarmonic::Tags::DerivativesOfSpacetimeMetricCompute<
+            3, Frame::Inertial>::name() == "DerivativesOfSpacetimeMetric");
+  CHECK(GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<
+            3, Frame::Inertial>::name() == "DerivSpacetimeMetric");
+
+  // Check that the compute items return the correct values
+  const DataVector test_vector{5., 4.};
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(spatial_metric) = 1.5;
+  get<0, 1>(spatial_metric) = 0.1;
+  get<0, 2>(spatial_metric) = 0.2;
+  get<1, 1>(spatial_metric) = 1.4;
+  get<1, 2>(spatial_metric) = 0.2;
+  get<2, 2>(spatial_metric) = 1.3;
+
+  auto lapse = make_with_value<Scalar<DataVector>>(test_vector, 0.94);
+
+  auto shift =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(shift) = 0.5;
+  get<1>(shift) = 0.6;
+  get<2>(shift) = 0.7;
+
+  auto dt_spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(dt_spatial_metric) = 0.05;
+  get<0, 1>(dt_spatial_metric) = 0.01;
+  get<0, 2>(dt_spatial_metric) = 0.02;
+  get<1, 1>(dt_spatial_metric) = 0.04;
+  get<1, 2>(dt_spatial_metric) = 0.02;
+  get<2, 2>(dt_spatial_metric) = 0.03;
+
+  auto dt_lapse = make_with_value<Scalar<DataVector>>(test_vector, 0.);
+  get(dt_lapse) = 0.04;
+
+  auto dt_shift =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(dt_shift) = 0.05;
+  get<1>(dt_shift) = 0.06;
+  get<2>(dt_shift) = 0.07;
+
+  auto deriv_spatial_metric =
+      make_with_value<tnsr::ijj<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                 0.);
+  get<0, 0, 0>(deriv_spatial_metric) = 0.1;
+  get<0, 0, 1>(deriv_spatial_metric) = 0.2;
+  get<0, 0, 2>(deriv_spatial_metric) = 0.3;
+  get<0, 1, 1>(deriv_spatial_metric) = 0.2;
+  get<0, 1, 2>(deriv_spatial_metric) = 0.1;
+  get<0, 2, 2>(deriv_spatial_metric) = 0.2;
+  get<1, 0, 0>(deriv_spatial_metric) = 0.3;
+  get<1, 0, 1>(deriv_spatial_metric) = 0.2;
+  get<1, 0, 2>(deriv_spatial_metric) = 0.1;
+  get<1, 1, 1>(deriv_spatial_metric) = 0.2;
+  get<1, 1, 2>(deriv_spatial_metric) = 0.3;
+  get<1, 2, 2>(deriv_spatial_metric) = 0.2;
+  get<2, 0, 0>(deriv_spatial_metric) = -0.1;
+  get<2, 0, 1>(deriv_spatial_metric) = -0.2;
+  get<2, 0, 2>(deriv_spatial_metric) = -0.3;
+  get<2, 1, 1>(deriv_spatial_metric) = -0.2;
+  get<2, 1, 2>(deriv_spatial_metric) = -0.1;
+  get<2, 2, 2>(deriv_spatial_metric) = -0.2;
+
+  auto deriv_lapse =
+      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(test_vector, 0.);
+  get<0>(deriv_lapse) = -0.1;
+  get<1>(deriv_lapse) = -0.2;
+  get<2>(deriv_lapse) = -0.3;
+
+  auto deriv_shift = make_with_value<tnsr::iJ<DataVector, 3, Frame::Inertial>>(
+      test_vector, 0.);
+  get<0, 0>(deriv_shift) = -0.05;
+  get<0, 1>(deriv_shift) = 0.06;
+  get<0, 2>(deriv_shift) = 0.07;
+  get<1, 0>(deriv_shift) = -0.03;
+  get<1, 1>(deriv_shift) = 0.04;
+  get<1, 2>(deriv_shift) = 0.03;
+  get<2, 0>(deriv_shift) = 0.01;
+  get<2, 1>(deriv_shift) = 0.02;
+  get<2, 2>(deriv_shift) = -0.01;
+
+  const auto& derivatives_of_spacetime_metric =
+      gr::derivatives_of_spacetime_metric(
+          lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
+          spatial_metric, dt_spatial_metric, deriv_spatial_metric);
+  const auto& deriv_spacetime_metric =
+      GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<
+          3, Frame::Inertial>::function(derivatives_of_spacetime_metric);
+
+  const auto& spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto& inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+
+  const auto& phi =
+      GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
+                               spatial_metric, deriv_spatial_metric);
+  const auto& pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  const auto& extrinsic_curvature = GeneralizedHarmonic::extrinsic_curvature(
+      spacetime_normal_vector, pi, phi);
+  const auto& trace_extrinsic_curvature =
+      trace(extrinsic_curvature, inverse_spatial_metric);
+
+  const auto& christoffel_first_kind =
+      gr::christoffel_first_kind(deriv_spatial_metric);
+  const auto& trace_christoffel_first_kind =
+      trace_last_indices(christoffel_first_kind, inverse_spatial_metric);
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>,
+          ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+          ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>,
+      db::AddComputeTags<
+          gr::Tags::SpacetimeNormalVectorCompute<3,
+                                                 Frame::Inertial, DataVector>,
+          gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
+                                                      DataVector>,
+          gr::Tags::InverseSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::SpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                       DataVector>,
+          gr::Tags::TraceSpatialChristoffelFirstKindCompute<3, Frame::Inertial,
+                                                            DataVector>,
+          GeneralizedHarmonic::Tags::PhiCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::PiCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivativesOfSpacetimeMetricCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivSpacetimeMetricCompute<
+              3, Frame::Inertial>  //,
+
+          >>(spatial_metric, lapse, shift, deriv_spatial_metric, deriv_lapse,
+             deriv_shift, dt_spatial_metric, dt_lapse, dt_shift);
+
+  CHECK(db::get<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(box) ==
+        phi);
+  CHECK(db::get<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>(box) == pi);
+  CHECK(db::get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(
+            box) == extrinsic_curvature);
+  CHECK(db::get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(box) ==
+        trace_extrinsic_curvature);
+  CHECK(db::get<gr::Tags::DerivativesOfSpacetimeMetric<3, Frame::Inertial,
+                                                       DataVector>>(box) ==
+        derivatives_of_spacetime_metric);
+  CHECK(db::get<gr::Tags::DerivSpacetimeMetric<3, Frame::Inertial, DataVector>>(
+            box) == deriv_spacetime_metric);
+
+  const auto other_box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          gr::Tags::SpacetimeNormalVector<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpacetimeMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>,
+      db::AddComputeTags<
+          GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<3,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivLapseCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::DerivShiftCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TimeDerivSpatialMetricCompute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TimeDerivLapseCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::TimeDerivShiftCompute<3,
+                                                           Frame::Inertial>>>(
+      lapse, shift, spacetime_normal_vector, inverse_spacetime_metric,
+      inverse_spatial_metric, phi, pi);
+  CHECK(
+      db::get<
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>(other_box) ==
+      deriv_spatial_metric);
+  CHECK(db::get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                              Frame::Inertial>>(other_box) == deriv_lapse);
+  CHECK(db::get<::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                              tmpl::size_t<3>, Frame::Inertial>>(other_box) ==
+        deriv_shift);
+  CHECK(
+      db::get<
+          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+          other_box) == dt_spatial_metric);
+  CHECK(db::get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(other_box) ==
+        dt_lapse);
+  CHECK(db::get<::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(
+            other_box) == dt_shift);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -24,6 +24,8 @@
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
+// IWYU pragma: no_forward_declare Tensor
+
 namespace {
 template <size_t Dim, typename DataType>
 void test_compute_spacetime_metric(const DataType& used_for_size) {

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -3,15 +3,22 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <array>
 #include <cstddef>
 #include <random>
+#include <string>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -54,7 +61,7 @@ void test_compute_spacetime_normal_vector(const DataType& used_for_size) {
 template <size_t Dim, typename DataType>
 void test_compute_spacetime_normal_one_form(const DataType& used_for_size) {
   MAKE_GENERATOR(generator);
-  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+  std::uniform_real_distribution<> distribution(-1., 1.);
   const auto lapse = make_with_random_values<Scalar<DataType>>(
       make_not_null(&generator), make_not_null(&distribution), used_for_size);
 
@@ -94,7 +101,7 @@ void test_compute_spatial_metric_lapse_shift(const T& used_for_size) {
     // Make sure spatial_metric isn't singular by adding
     // large enough positive diagonal values.
     for (size_t i = 0; i < Dim; ++i) {
-      spatial_metric_l.get(i, i) += 4.0;
+      spatial_metric_l.get(i, i) += 4.;
     }
     return spatial_metric_l;
   }();
@@ -136,4 +143,118 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_extrinsic_curvature,
                                     (1, 2, 3));
+
+  // Check that compute items work correctly in the DataBox
+  // First, check that the names are correct
+  CHECK(gr::Tags::SpacetimeMetricCompute<3, Frame::Inertial,
+                                         DataVector>::name() ==
+        "SpacetimeMetric");
+  CHECK(
+      gr::Tags::SpatialMetricCompute<3, Frame::Inertial, DataVector>::name() ==
+      "SpatialMetric");
+  CHECK(gr::Tags::InverseSpacetimeMetric<3, Frame::Inertial,
+                                         DataVector>::name() ==
+        "InverseSpacetimeMetric");
+  CHECK(
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>::name() ==
+      "InverseSpatialMetric");
+  CHECK(gr::Tags::ShiftCompute<3, Frame::Inertial, DataVector>::name() ==
+        "Shift");
+  CHECK(gr::Tags::LapseCompute<3, Frame::Inertial, DataVector>::name() ==
+        "Lapse");
+  CHECK(gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial,
+                                                DataVector>::name() ==
+        "SpacetimeNormalOneForm");
+  CHECK(
+      gr::Tags::SpacetimeNormalVector<3, Frame::Inertial, DataVector>::name() ==
+      "SpacetimeNormalVector");
+
+  // Second, put the compute items into a data box and check that they
+  // put the correct results
+  // Let's start with a known spacetime metric, and then test the
+  // compute items that depend on the spacetime metric
+  DataVector test_vector{5., 4.};
+  auto spacetime_metric =
+      make_with_value<tnsr::aa<DataVector, 3, Frame::Inertial>>(test_vector,
+                                                                0.);
+  get<0, 0>(spacetime_metric) = -1.5;
+  get<0, 1>(spacetime_metric) = 0.1;
+  get<0, 2>(spacetime_metric) = 0.2;
+  get<0, 3>(spacetime_metric) = 0.3;
+  get<1, 1>(spacetime_metric) = 1.4;
+  get<1, 2>(spacetime_metric) = 0.2;
+  get<1, 3>(spacetime_metric) = 0.1;
+  get<2, 2>(spacetime_metric) = 1.3;
+  get<2, 3>(spacetime_metric) = 0.1;
+  get<3, 3>(spacetime_metric) = 1.2;
+
+  const auto& spatial_metric = gr::spatial_metric(spacetime_metric);
+  const auto& det_and_inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric);
+  const auto& det_spatial_metric = det_and_inverse_spatial_metric.first;
+  const auto& sqrt_det_spatial_metric =
+      Scalar<DataVector>{sqrt(get(det_spatial_metric))};
+  const auto& inverse_spatial_metric = det_and_inverse_spatial_metric.second;
+  const auto& shift = gr::shift(spacetime_metric, inverse_spatial_metric);
+  const auto& lapse = gr::lapse(shift, spacetime_metric);
+  const auto& inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>,
+      db::AddComputeTags<
+          gr::Tags::SpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
+                                                      DataVector>,
+          gr::Tags::DetSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::SqrtDetSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpatialMetricCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::ShiftCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::LapseCompute<3, Frame::Inertial, DataVector>,
+          gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial,
+                                                  DataVector>,
+          gr::Tags::SpacetimeNormalVectorCompute<3, Frame::Inertial,
+                                                 DataVector>>>(
+      spacetime_metric);
+  CHECK(db::get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(box) ==
+        spatial_metric);
+  CHECK(
+      db::get<
+          gr::Tags::DetAndInverseSpatialMetric<3, Frame::Inertial, DataVector>>(
+          box) == det_and_inverse_spatial_metric);
+  CHECK(db::get<gr::Tags::DetSpatialMetric<DataVector>>(box) ==
+        det_spatial_metric);
+  CHECK(db::get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(box) ==
+        sqrt_det_spatial_metric);
+  CHECK(db::get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>(
+            box) == inverse_spatial_metric);
+  CHECK(db::get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(box) == shift);
+  CHECK(db::get<gr::Tags::Lapse<DataVector>>(box) == lapse);
+  CHECK(
+      db::get<gr::Tags::InverseSpacetimeMetric<3, Frame::Inertial, DataVector>>(
+          box) == inverse_spacetime_metric);
+  CHECK(
+      db::get<gr::Tags::SpacetimeNormalOneForm<3, Frame::Inertial, DataVector>>(
+          box) ==
+      gr::spacetime_normal_one_form<3, Frame::Inertial, DataVector>(lapse));
+  CHECK(
+      db::get<gr::Tags::SpacetimeNormalVector<3, Frame::Inertial, DataVector>>(
+          box) ==
+      gr::spacetime_normal_vector<3, Frame::Inertial, DataVector>(lapse,
+                                                                  shift));
+
+  // Now let's put the lapse, shift, and spatial metric into the databox
+  // and test that we can compute the correct spacetime metric
+  const auto second_box = db::create<
+      db::AddSimpleTags<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        gr::Tags::Lapse<DataVector>,
+                        gr::Tags::Shift<3, Frame::Inertial, DataVector>>,
+      db::AddComputeTags<
+          gr::Tags::SpacetimeMetricCompute<3, Frame::Inertial, DataVector>>>(
+      spatial_metric, lapse, shift);
+  CHECK(db::get<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>(
+            second_box) == spacetime_metric);
 }


### PR DESCRIPTION
## Proposed changes

Add and use a generic reduction observer to observer constraints in the GH executable. See the last commit only.

### Types of changes:

- [ ] Bugfix
- [x] New feature
